### PR TITLE
Fix codegen and runtime regressions for 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ benchmarks/COMPREHENSIVE_BENCHMARK_RESULTS.md
 benchmarks/quick_benchmark.sh
 benchmarks/run_comprehensive_comparison.sh
 vscode-seen/package-lock.json
+.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Seen compiler will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-04-28
+
+### Fixed
+
+#### Codegen and runtime regressions
+- Fixed `Float32` pointer dereference casts to `Int` so codegen emits a direct floating-point-to-integer conversion instead of invalid LLVM IR.
+- Fixed `&&` and `||` lexing, type inference, and short-circuit planning, and fixed Bool-aware `&` / `|` lowering to emit type-correct `i1` operations with integer predicate coercion.
+- Fixed no-value class method metadata so calls lower with the `void` ABI instead of as integer-returning calls.
+- Fixed implicit-`this` dotted receiver lookup for nested property method calls, preserving object receiver pointers through chained member access.
+- Made the runtime timestamp-period fallback weak so native implementations can override it at link time.
+- Added focused regression coverage for the codegen/runtime fixes and the no-value method-call IR shape.
+
 ## [0.7.0] - 2026-04-28
 
 ### Added

--- a/compiler_seen/src/codegen/ir_binary_expr.seen
+++ b/compiler_seen/src/codegen/ir_binary_expr.seen
@@ -328,6 +328,8 @@ fun exprProducesBoolImpl(exprType: String, operator: String) r: Int {
     if operator == ">=" { return 1 }
     if operator == "and" { return 1 }
     if operator == "or" { return 1 }
+    if operator == "&&" { return 1 }
+    if operator == "||" { return 1 }
     if operator == "not" { return 1 }
     return 0
 }

--- a/compiler_seen/src/codegen/ir_binary_plan.seen
+++ b/compiler_seen/src/codegen/ir_binary_plan.seen
@@ -118,10 +118,10 @@ fun planBinaryFmaSidesImpl(fmaCandidate: Bool, leftKind: String,
 }
 
 fun shortCircuitBinaryActionImpl(operator: String) r: Int {
-    if operator == "and" {
+    if operator == "and" or operator == "&&" {
         return 1
     }
-    if operator == "or" {
+    if operator == "or" or operator == "||" {
         return 2
     }
     return 0

--- a/compiler_seen/src/codegen/ir_decl_scan.seen
+++ b/compiler_seen/src/codegen/ir_decl_scan.seen
@@ -1,7 +1,7 @@
 // ir_decl_scan.seen — Pass 1 declaration-scan helpers
 // Shared registry mutation helpers extracted from llvm_ir_gen.seen registerDeclarations().
 
-import parser.real_parser.{ProgramNode, FunctionNode}
+import parser.real_parser.{ProgramNode, FunctionNode, BlockNode}
 import str.string.{StringBuilder}
 import codegen.ir_optimization.{parseGlobalVarMutable, parseGlobalVarType, pipeGet}
 import codegen.ir_decl_items.{normalizeDeclaredTypeNodeImpl}
@@ -223,10 +223,8 @@ fun collectStructMethodSignaturesImpl(className: String,
     while methodIdx < methods.length() {
         let method = methods[methodIdx]
         let safeMethodName = sanitizeDeclSignaturePartImpl(method.name)
-        let declaredReturnType = normalizeDeclaredTypeNodeImpl(method.returnType)
         let safeRetType = sanitizeDeclSignaturePartImpl(
-            resolveMethodReturnTypeImpl(className, method.name,
-                declaredReturnType, ""))
+            resolveStructMethodSignatureReturnTypeImpl(className, method))
 
         methodNames = appendDelimitedDeclSignaturePartImpl(methodNames, ",",
             safeMethodName, methodIdx)
@@ -248,6 +246,50 @@ fun collectStructMethodSignaturesImpl(className: String,
     }
     methodNamesBox[0] = methodNames
     methodRetTypesBox[0] = methodRetTypes
+}
+
+fun blockContainsValueReturnImpl(block: BlockNode) r: Bool {
+    var stmtIdx = 0
+    while stmtIdx < block.statements.length() {
+        let stmt = block.statements[stmtIdx]
+        if stmt.kind == "Return" {
+            if stmt.returnValue.kind != "" and stmt.returnValue.kind != "None" {
+                return true
+            }
+        }
+        if stmt.kind == "If" {
+            if blockContainsValueReturnImpl(stmt.thenBranch) {
+                return true
+            }
+            if blockContainsValueReturnImpl(stmt.elseBranch) {
+                return true
+            }
+        }
+        if stmt.kind == "While" {
+            if blockContainsValueReturnImpl(stmt.loopBody) {
+                return true
+            }
+        }
+        stmtIdx = stmtIdx + 1
+    }
+    return false
+}
+
+fun resolveStructMethodSignatureReturnTypeImpl(className: String,
+    method: FunctionNode) r: String {
+
+    let declaredReturnType = normalizeDeclaredTypeNodeImpl(method.returnType)
+    if declaredReturnType != "" and declaredReturnType != "Unknown" {
+        return declaredReturnType
+    }
+    if method.name == "new" {
+        return className
+    }
+    if blockContainsValueReturnImpl(method.body) {
+        return resolveMethodReturnTypeImpl(className, method.name,
+            declaredReturnType, "")
+    }
+    return "Void"
 }
 
 fun recordCrossModuleDeclareImpl(symbolName: String, declStr: String, visibility: String,

--- a/compiler_seen/src/codegen/ir_infer_type.seen
+++ b/compiler_seen/src/codegen/ir_infer_type.seen
@@ -40,7 +40,11 @@ fun cacheMethodBoolSuffixType(callee: String, funcLen: Int,
 
 fun inferBinaryTypeImpl(operator: String, leftType: String, rightType: String) r: String {
     // Comparison and logical operators always return Bool
-    if operator == "==" or operator == "!=" or operator == "<" or operator == ">" or operator == "<=" or operator == ">=" or operator == "and" or operator == "or" {
+    if operator == "==" or operator == "!=" or operator == "<" or operator == ">" or operator == "<=" or operator == ">=" or operator == "and" or operator == "or" or operator == "&&" or operator == "||" {
+        return "Bool"
+    }
+    if (operator == "&" or operator == "|") and
+        (leftType == "Bool" or rightType == "Bool") {
         return "Bool"
     }
     // String concatenation via +

--- a/compiler_seen/src/codegen/ir_type_ops.seen
+++ b/compiler_seen/src/codegen/ir_type_ops.seen
@@ -123,6 +123,26 @@ fun emitBinaryOpImpl(output: StringBuilder, regBox: Array<Int>, boundsLabelBox: 
 
     let resultReg = getNextRegFn(regBox)
     var opHandled = false
+    if (operator == "&" or operator == "|") and
+        (leftType == "Bool" or rightType == "Bool") {
+
+        var boolLeftReg = leftReg
+        if leftType != "Bool" {
+            boolLeftReg = getNextRegFn(regBox)
+            output.append("  " + boolLeftReg + " = icmp ne i64 " + leftReg + ", 0\n")
+        }
+        var boolRightReg = rightReg
+        if rightType != "Bool" {
+            boolRightReg = getNextRegFn(regBox)
+            output.append("  " + boolRightReg + " = icmp ne i64 " + rightReg + ", 0\n")
+        }
+        if operator == "&" {
+            output.append("  " + resultReg + " = and i1 " + boolLeftReg + ", " + boolRightReg + "\n")
+        } else {
+            output.append("  " + resultReg + " = or i1 " + boolLeftReg + ", " + boolRightReg + "\n")
+        }
+        return resultReg
+    }
     if operator == "-" {
         if leftType == "Float" or rightType == "Float" {
             if leftType == "Float" and rightType == "Float" {
@@ -1242,6 +1262,12 @@ fun emitCastExprImpl(output: StringBuilder, regBox: Array<Int>, innerReg: String
         castResultReg = cReg
         castDone = 1
     }
+    // Float32 -> Int
+    if castDone == 0 and innerType == "Float32" and castTarget == "Int" {
+        output.append("  " + cReg + " = fptosi float " + innerReg + " to i64\n")
+        castResultReg = cReg
+        castDone = 1
+    }
     // Int -> Bool
     if castDone == 0 and innerType == "Int" and castTarget == "Bool" {
         output.append("  " + cReg + " = trunc i64 " + innerReg + " to i1\n")
@@ -1341,6 +1367,12 @@ fun emitCastExprImpl(output: StringBuilder, regBox: Array<Int>, innerReg: String
     // Float -> Float32 (fptrunc double to float)
     if castDone == 0 and innerType == "Float" and castTarget == "Float32" {
         output.append("  " + cReg + " = fptrunc double " + innerReg + " to float\n")
+        castResultReg = cReg
+        castDone = 1
+    }
+    // Int -> Float32
+    if castDone == 0 and innerType == "Int" and castTarget == "Float32" {
+        output.append("  " + cReg + " = sitofp i64 " + innerReg + " to float\n")
         castResultReg = cReg
         castDone = 1
     }

--- a/compiler_seen/src/codegen/llvm_ir_gen.seen
+++ b/compiler_seen/src/codegen/llvm_ir_gen.seen
@@ -5030,12 +5030,21 @@ class LLVMIRGenerator {
             return ""
         }
         let thisType = varTypes[thisIdx]
-        let fieldIdx = getFieldInfo(thisType, receiverName)
-        if fieldIdx < 0 {
+        var intermediateType = ""
+        if receiverName.contains(".") {
+            intermediateType = resolveMethodFieldPathTypeImpl(thisType,
+                receiverName, structNames, structFieldNames, structFieldTypes,
+                structMethodNames, structMethodRetTypes)
+        } else {
+            let fieldIdx = getFieldInfo(thisType, receiverName)
+            if fieldIdx < 0 {
+                return ""
+            }
+            intermediateType = getSeenFieldType(thisType, receiverName)
+        }
+        if intermediateType == "" {
             return ""
         }
-
-        let intermediateType = getSeenFieldType(thisType, receiverName)
         return emitPreparedImplicitThisReceiverMemberAccessImpl(output, g_regBox,
             receiverName, fieldName, varRegs[thisIdx], thisType,
             intermediateType, getFieldType(intermediateType, fieldName),
@@ -8477,13 +8486,19 @@ class LLVMIRGenerator {
         var literalReceiverFieldType = ""
         if memberPlan.shouldTryLiteralReceiver {
             var chainedPathType = ""
-            if expr.literalValue.contains(".") {
-                chainedPathType = resolveChainedPathType(expr.literalValue)
-            }
             var thisType = ""
             let thisIdx = findActiveVariableIndexImpl(varNames, activeVarCount, "this")
             if thisIdx >= 0 {
                 thisType = varTypes[thisIdx]
+            }
+            if expr.literalValue.contains(".") {
+                chainedPathType = resolveChainedPathType(expr.literalValue)
+                if chainedPathType == "" and thisType != "" {
+                    chainedPathType = resolveMethodFieldPathTypeImpl(thisType,
+                        expr.literalValue, structNames, structFieldNames,
+                        structFieldTypes, structMethodNames,
+                        structMethodRetTypes)
+                }
             }
             literalReceiverFieldType = inferLiteralReceiverMemberAccessTypeImpl(
                 expr.literalValue, fieldName, chainedPathType, literalValueType,

--- a/compiler_seen/src/lexer/lexer.seen
+++ b/compiler_seen/src/lexer/lexer.seen
@@ -1097,6 +1097,20 @@ class SeenLexer {
             emitToken(SeenTokenType.RightShift, ">>", 2)
             return true
         }
+        if char == '&' and nextChar == '&' {
+            if traceVerbose { traceLexVerbose("handleOperator matched &&") }
+            advance()
+            advance()
+            emitToken(SeenTokenType.LogicalAnd, "&&", 2)
+            return true
+        }
+        if char == '|' and nextChar == '|' {
+            if traceVerbose { traceLexVerbose("handleOperator matched ||") }
+            advance()
+            advance()
+            emitToken(SeenTokenType.LogicalOr, "||", 2)
+            return true
+        }
         if char == '-' and nextChar == '>' {
             if traceVerbose { traceLexVerbose("handleOperator matched ->") }
             advance()
@@ -1178,6 +1192,8 @@ class SeenLexer {
         if op == "-=" { return SeenTokenType.MinusEqual }
         if op == "*=" { return SeenTokenType.MultiplyEqual }
         if op == "/=" { return SeenTokenType.DivideEqual }
+        if op == "&&" { return SeenTokenType.LogicalAnd }
+        if op == "||" { return SeenTokenType.LogicalOr }
         if op == "->" { return SeenTokenType.Arrow }
         if op == "?." { return SeenTokenType.SafeNavigation }
         if op == "?:" { return SeenTokenType.Elvis }

--- a/seen_runtime/seen_runtime.c
+++ b/seen_runtime/seen_runtime.c
@@ -8088,7 +8088,7 @@ SEEN_BOOTSTRAP_WEAK int64_t seen_chunk_brick_from_rle(int64_t p, int64_t s) { (v
 SEEN_BOOTSTRAP_WEAK int64_t seen_chunk_brick_load(int64_t p) { (void)p; return 0; }
 SEEN_BOOTSTRAP_WEAK void seen_chunk_brick_free(int64_t p) { (void)p; }
 void seen_quality_log(int64_t level, int64_t msg_ptr, int64_t msg_len) { (void)level; (void)msg_ptr; (void)msg_len; }
-int64_t seen_vk_get_physical_device_timestamp_period(void) { return 0; }
+SEEN_BOOTSTRAP_WEAK int64_t seen_vk_get_physical_device_timestamp_period(void) { return 0; }
 __attribute__((weak)) int64_t seen_vk_create_query_pool(int64_t a, int64_t b) { (void)a; (void)b; return 0; }
 __attribute__((weak)) void seen_vk_cmd_write_timestamp(int64_t a, int64_t b, int64_t c) { (void)a; (void)b; (void)c; }
 

--- a/tests/codegen/test_bool_helper_logical_regression.seen
+++ b/tests/codegen/test_bool_helper_logical_regression.seen
@@ -1,0 +1,20 @@
+// Regression FEL-30: Bool-returning helpers in logical conditions must produce
+// type-correct i1 short-circuit IR.
+
+fun isSpace(value: Int) r: Bool {
+    return value == 9 || value == 10 || value == 13 || value == 32
+}
+
+fun isDigit(value: Int) r: Bool {
+    return value >= 48 && value <= 57
+}
+
+fun main() r: Int {
+    let ch = 32
+    if ch > 0 && (isSpace(ch) || isDigit(ch)) {
+        println("PASS: Bool helper logical conditions")
+        return 0
+    }
+    println("FAIL: Bool helper logical conditions")
+    return 1
+}

--- a/tests/codegen/test_float32_ptr_deref_cast_regression.seen
+++ b/tests/codegen/test_float32_ptr_deref_cast_regression.seen
@@ -1,0 +1,14 @@
+// Regression FEL-29: direct Float32 pointer deref casts to Int must lower with
+// fptosi float -> i64, not an invalid raw float store into an Int slot.
+
+fun main() r: Int {
+    let addr = ptr_alloc_i32()
+    ptr_store_f32(addr, 7.75 as Float32)
+    let period = ptr_deref_f32(addr) as Int
+    if period == 7 {
+        println("PASS: Float32 ptr deref cast")
+        return 0
+    }
+    println("FAIL: Float32 ptr deref cast = " + period.toString())
+    return 1
+}

--- a/tests/codegen/test_nested_property_receiver_regression.seen
+++ b/tests/codegen/test_nested_property_receiver_regression.seen
@@ -1,0 +1,76 @@
+// Regression FEL-32: nested property method receivers reached through implicit
+// this must preserve the object pointer through a large registration-like path.
+
+class PropertyRegistry {
+    var lastId: Int
+    var lastValue: Float
+
+    static fun new() r: PropertyRegistry {
+        return PropertyRegistry { lastId: 0, lastValue: 0.0 }
+    }
+
+    fun registerFloat(id: Int, defaultValue: Float) {
+        this.lastId = id
+        this.lastValue = defaultValue
+    }
+}
+
+class EngineServices {
+    var props: PropertyRegistry
+
+    static fun new() r: EngineServices {
+        return EngineServices { props: PropertyRegistry.new() }
+    }
+}
+
+class Engine {
+    var services: EngineServices
+
+    static fun new() r: Engine {
+        return Engine { services: EngineServices.new() }
+    }
+}
+
+class Launcher {
+    var engine: Engine
+
+    static fun new() r: Launcher {
+        return Launcher { engine: Engine.new() }
+    }
+
+    fun registerAll() {
+        engine.services.props.registerFloat(1, 1.0)
+        engine.services.props.registerFloat(2, 2.0)
+        engine.services.props.registerFloat(3, 3.0)
+        engine.services.props.registerFloat(4, 4.0)
+        engine.services.props.registerFloat(5, 5.0)
+        engine.services.props.registerFloat(6, 6.0)
+        engine.services.props.registerFloat(7, 7.0)
+        engine.services.props.registerFloat(8, 8.0)
+        engine.services.props.registerFloat(9, 9.0)
+        engine.services.props.registerFloat(10, 10.0)
+        engine.services.props.registerFloat(11, 11.0)
+        engine.services.props.registerFloat(12, 12.0)
+        engine.services.props.registerFloat(13, 13.0)
+        engine.services.props.registerFloat(14, 21.0)
+    }
+
+    fun lastId() r: Int {
+        return engine.services.props.lastId
+    }
+
+    fun lastValue() r: Float {
+        return engine.services.props.lastValue
+    }
+}
+
+fun main() r: Int {
+    let launcher = Launcher.new()
+    launcher.registerAll()
+    if launcher.lastId() == 14 && launcher.lastValue() > 20.9 {
+        println("PASS: nested property receiver")
+        return 0
+    }
+    println("FAIL: nested property receiver")
+    return 1
+}

--- a/tests/misc_root_tests/seen_fix_regressions.sh
+++ b/tests/misc_root_tests/seen_fix_regressions.sh
@@ -36,6 +36,9 @@ WHEN_ENUM_EXHAUSTIVE_OK_SRC="$ROOT_DIR/tests/fixtures/current_limitations/when_e
 WHEN_ENUM_ELSE_OK_SRC="$ROOT_DIR/tests/fixtures/current_limitations/when_enum_else_ok.seen"
 UNRESOLVED_FREE_CALL_SRC="$ROOT_DIR/tests/fixtures/current_limitations/unresolved_free_call.seen"
 BOOL_RETURN_COERCION_SRC="$ROOT_DIR/tests/codegen/test_bool_return_int_coercion_regression.seen"
+BOOL_HELPER_LOGICAL_SRC="$ROOT_DIR/tests/codegen/test_bool_helper_logical_regression.seen"
+FLOAT32_PTR_DEREF_CAST_SRC="$ROOT_DIR/tests/codegen/test_float32_ptr_deref_cast_regression.seen"
+NESTED_PROPERTY_RECEIVER_SRC="$ROOT_DIR/tests/codegen/test_nested_property_receiver_regression.seen"
 FEL22_TYPED_STORE_RETURN_SRC="$ROOT_DIR/tests/codegen/test_fel22_typed_store_return_regression.seen"
 PTR_I64_ALIAS_SRC="$ROOT_DIR/tests/codegen/test_ptr_i64_alias_regression.seen"
 RUNTIME_FILE_BYTES_SRC="$ROOT_DIR/tests/codegen/test_runtime_file_bytes_regression.seen"
@@ -112,6 +115,60 @@ run_success_case() {
     if ! run_compile "$source_file" "$output_file" "$log_file"; then
         echo "FAIL: $label compile failed"
         cat "$log_file"
+        exit 1
+    fi
+
+    if ! "$output_file" >/dev/null 2>&1; then
+        echo "FAIL: $label binary exited non-zero"
+        cat "$log_file"
+        exit 1
+    fi
+
+    echo "PASS: $label"
+}
+
+run_compile_no_cache_no_fork() {
+    local source_file="$1"
+    local output_file="$2"
+    local log_file="$3"
+
+    if [[ "$BUILD_CMD" == "build" ]]; then
+        timeout 120 "$COMPILER" build "$source_file" -o "$output_file" --fast --no-cache --no-fork >"$log_file" 2>&1
+    else
+        timeout 120 "$COMPILER" compile "$source_file" "$output_file" --fast --no-cache --no-fork >"$log_file" 2>&1
+    fi
+}
+
+run_success_case_with_ir_check() {
+    local label="$1"
+    local source_file="$2"
+    local output_file="$3"
+    local log_file="$4"
+    local expected_ir_pattern="$5"
+    local rejected_ir_pattern="$6"
+
+    cleanup_seen_artifacts
+    if ! run_compile_no_cache_no_fork "$source_file" "$output_file" "$log_file"; then
+        echo "FAIL: $label compile failed"
+        cat "$log_file"
+        exit 1
+    fi
+
+    if [[ ! -f /tmp/seen_module_0.ll ]]; then
+        echo "FAIL: $label did not leave LLVM IR to inspect"
+        cat "$log_file"
+        exit 1
+    fi
+
+    if ! grep -Eq "$expected_ir_pattern" /tmp/seen_module_0.ll; then
+        echo "FAIL: $label did not emit the expected LLVM IR"
+        grep -n "PropertyRegistry_registerFloat" /tmp/seen_module_0.ll || true
+        exit 1
+    fi
+
+    if [[ -n "$rejected_ir_pattern" ]] && grep -Eq "$rejected_ir_pattern" /tmp/seen_module_0.ll; then
+        echo "FAIL: $label emitted rejected LLVM IR"
+        grep -n "PropertyRegistry_registerFloat" /tmp/seen_module_0.ll || true
         exit 1
     fi
 
@@ -1621,6 +1678,9 @@ run_check_success_case "enum matches stay allowed when all variants are covered"
 run_check_success_case "enum matches stay allowed with else arm" "$WHEN_ENUM_ELSE_OK_SRC" "$TMP_ROOT/when_enum_else_ok.log"
 run_check_failure_case "unresolved free function calls are diagnosed" "$UNRESOLVED_FREE_CALL_SRC" "$TMP_ROOT/unresolved_free_call.log" 'unresolved function `chunkInBounds`'
 run_success_case "Bool returns coerce Int predicates to i1" "$BOOL_RETURN_COERCION_SRC" "$TMP_ROOT/bool_return_coercion" "$TMP_ROOT/bool_return_coercion.log"
+run_success_case "Bool helper logical conditions stay verifier-clean" "$BOOL_HELPER_LOGICAL_SRC" "$TMP_ROOT/bool_helper_logical" "$TMP_ROOT/bool_helper_logical.log"
+run_success_case "Float32 pointer deref casts directly to Int" "$FLOAT32_PTR_DEREF_CAST_SRC" "$TMP_ROOT/float32_ptr_deref_cast" "$TMP_ROOT/float32_ptr_deref_cast.log"
+run_success_case_with_ir_check "nested property method receivers preserve object pointer" "$NESTED_PROPERTY_RECEIVER_SRC" "$TMP_ROOT/nested_property_receiver" "$TMP_ROOT/nested_property_receiver.log" 'call void @PropertyRegistry_registerFloat' '= call i64 @PropertyRegistry_registerFloat'
 run_success_case "FEL-22 typed stores and Float returns stay verifier-clean" "$FEL22_TYPED_STORE_RETURN_SRC" "$TMP_ROOT/fel22_typed_store_return" "$TMP_ROOT/fel22_typed_store_return.log"
 run_success_case "ptr_deref_i64 and ptr_store_i64 lower to runtime builtins" "$PTR_I64_ALIAS_SRC" "$TMP_ROOT/ptr_i64_alias" "$TMP_ROOT/ptr_i64_alias.log"
 run_success_case "runtime file byte arrays use pointer ABI" "$RUNTIME_FILE_BYTES_SRC" "$TMP_ROOT/runtime_file_bytes" "$TMP_ROOT/runtime_file_bytes.log"


### PR DESCRIPTION
- Lower Float32/Int casts with type-correct LLVM conversions
- Handle symbolic logical operators through lexing, inference, and codegen
- Emit Bool-aware bitwise operations as i1 operations
- Preserve void ABI metadata for no-value class methods
- Resolve nested implicit-this receiver paths correctly
- Allow runtime timestamp fallback to be overridden
- Add focused regression coverage and the 0.7.1 changelog entry