### PR TITLE
feat(FEL-631): harden registry ingestion and review contracts

### DIFF
--- a/contracts/package-registry/v1/README.md
+++ b/contracts/package-registry/v1/README.md
@@ -1,10 +1,11 @@
 # Seen package registry contract v1
 
 This directory is the normative v1 wire, manifest, resolution, lock, archive,
-and trust contract shared by Seen clients and the registry service. A producer
-or consumer claiming v1 conformance must satisfy the schemas, semantic rules,
-and executable fixtures together. A contract change updates those artifacts
-and both client and service conformance tests atomically.
+source-proof, provenance, scan-attestation, release-state, and trust contract
+shared by Seen clients and the registry service. A producer or consumer
+claiming v1 conformance must satisfy the schemas, semantic rules, and executable
+fixtures together. A contract change updates those artifacts and both client
+and service conformance tests atomically.
 
 Contract paths are host-neutral. Development uses
 `https://seen.dev.yousef.codes/packages`; production promotion later changes
@@ -222,9 +223,20 @@ The executable transition fixture keeps four orthogonal dimensions:
 lifecycle, visibility, resolver availability, and retention. A public release
 cannot use the private first-scan-to-ready edge: it passes a distinct first
 scan, waits at least 72 hours, and then enters a distinct second-scan state with
-a fresh source-proof check. Scanner outages and inconclusive results retry from
-quarantine or delay while remaining unavailable; only definitive policy
-failure rejects a reserved version.
+a fresh source-proof check. The verifier resolves the requested forge ref into
+an immutable commit at verification and at every pre-activation recheck; any
+repository, ref, or commit drift fails with
+`source_proof_mutable_ref_changed`. Scanner outages and inconclusive results
+retry from quarantine or delay while remaining unavailable; only definitive
+policy failure rejects a reserved version.
+
+The 72-hour delay is exactly 259,200 seconds measured by the registry server's
+UTC clock. The second scan may start when elapsed time is greater than or equal
+to that boundary; one second earlier is denied. Ready-to-active promotion uses
+a compare-and-swap state revision. Only the exact archive and source-proof
+digests captured by the successful review may be promoted. Replaying the same
+promotion key with those exact inputs is idempotent; a competing stale write
+fails without publishing a second blob or metadata record.
 
 Package identity, version, and archive digest are reserved atomically before a
 release enters quarantine. Manifest/capability data derived from the archive is
@@ -232,6 +244,17 @@ bound immutably to that digest. Later provenance and scan rechecks are
 append-only attestations. Blob promotion must complete before resolver-visible
 signed metadata is published. Yanking and security quarantine change signed
 availability, not lifecycle history or bytes; neither allows version reuse.
+
+`schemas/scan-attestation-v1.schema.json` is the normative isolated-scan record.
+It binds the mounted and scanner-observed archive and source-proof digests to
+the immutable release, records rootless ephemeral execution and resource
+limits, and makes only a `passed` / `promotion-eligible` result usable by a
+later state transition. `fixtures/scan-attestation-v1.json` and
+`fixtures/scan-attestation-failure-cases-v1.json` freeze fail-closed behavior
+for scanner crashes, timeouts, missing results or digests, and inconsistent
+archive or source-proof observations. `fixtures/release-transitions.json`
+freezes the exact delay boundary, idempotent replay, state-race, and reviewed
+input-binding traces.
 
 Private package names and versions are not enumerable. A private release may be
 soft-deleted, but its identity/version reservation and audit record remain; blob

--- a/contracts/package-registry/v1/fixtures/archive-policy-cases.json
+++ b/contracts/package-registry/v1/fixtures/archive-policy-cases.json
@@ -407,6 +407,58 @@
         "notes": "The validator stopped before trusting any partial result."
       },
       "expected": "reject", "error_code": "archive_validation_timeout"
+    },
+    {
+      "name": "fifo_entry",
+      "description": "A FIFO entry is rejected before extraction even in a rootless worker.",
+      "archive": {
+        "format": "tar+gzip", "parser_result": "complete",
+        "stats": {"compressed_bytes": 1024, "expanded_bytes": 512, "entry_count": 2, "max_regular_file_bytes": 512, "max_path_bytes": 13, "max_path_depth": 2, "compression_ratio": 0.5},
+        "entries": [
+          {"header_path": "Seen.toml", "effective_path": "Seen.toml", "type": "regular-file", "size": 512, "mode": "0644", "included_by_manifest": true, "header_override": "none"},
+          {"header_path": "assets/pipe", "effective_path": "assets/pipe", "type": "fifo", "size": 0, "mode": "0644", "included_by_manifest": true, "header_override": "none"}
+        ]
+      },
+      "expected": "reject", "error_code": "archive_entry_type_forbidden", "failure_entry": 1
+    },
+    {
+      "name": "socket_entry",
+      "description": "A socket entry is rejected before any extractor can materialize it.",
+      "archive": {
+        "format": "tar+gzip", "parser_result": "complete",
+        "stats": {"compressed_bytes": 1024, "expanded_bytes": 512, "entry_count": 2, "max_regular_file_bytes": 512, "max_path_bytes": 15, "max_path_depth": 2, "compression_ratio": 0.5},
+        "entries": [
+          {"header_path": "Seen.toml", "effective_path": "Seen.toml", "type": "regular-file", "size": 512, "mode": "0644", "included_by_manifest": true, "header_override": "none"},
+          {"header_path": "assets/socket", "effective_path": "assets/socket", "type": "socket", "size": 0, "mode": "0644", "included_by_manifest": true, "header_override": "none"}
+        ]
+      },
+      "expected": "reject", "error_code": "archive_entry_type_forbidden", "failure_entry": 1
+    },
+    {
+      "name": "sparse_file_entry",
+      "description": "A sparse file is rejected from header metadata without trusting its apparent expanded size.",
+      "archive": {
+        "format": "tar+gzip", "parser_result": "complete",
+        "stats": {"compressed_bytes": 16384, "expanded_bytes": 1049088, "entry_count": 2, "max_regular_file_bytes": 512, "max_path_bytes": 17, "max_path_depth": 2, "compression_ratio": 64.03125},
+        "entries": [
+          {"header_path": "Seen.toml", "effective_path": "Seen.toml", "type": "regular-file", "size": 512, "mode": "0644", "included_by_manifest": true, "header_override": "none"},
+          {"header_path": "assets/sparse.db", "effective_path": "assets/sparse.db", "type": "sparse-file", "size": 1048576, "mode": "0644", "included_by_manifest": true, "header_override": "none"}
+        ]
+      },
+      "expected": "reject", "error_code": "archive_entry_type_forbidden", "failure_entry": 1
+    },
+    {
+      "name": "unknown_entry_type",
+      "description": "An unknown archive entry type fails closed instead of being coerced to a regular file.",
+      "archive": {
+        "format": "tar+gzip", "parser_result": "complete",
+        "stats": {"compressed_bytes": 1024, "expanded_bytes": 512, "entry_count": 2, "max_regular_file_bytes": 512, "max_path_bytes": 14, "max_path_depth": 2, "compression_ratio": 0.5},
+        "entries": [
+          {"header_path": "Seen.toml", "effective_path": "Seen.toml", "type": "regular-file", "size": 512, "mode": "0644", "included_by_manifest": true, "header_override": "none"},
+          {"header_path": "assets/mystery", "effective_path": "assets/mystery", "type": "unknown", "size": 0, "mode": "0644", "included_by_manifest": true, "header_override": "none"}
+        ]
+      },
+      "expected": "reject", "error_code": "archive_entry_type_forbidden", "failure_entry": 1
     }
   ]
 }

--- a/contracts/package-registry/v1/fixtures/release-transitions.json
+++ b/contracts/package-registry/v1/fixtures/release-transitions.json
@@ -368,6 +368,281 @@
       "failure_step": 3
     }
   ],
+  "promotion_protocol": {
+    "server_clock": "rfc3339-utc",
+    "public_delay_seconds": 259200,
+    "delay_comparison": "elapsed-greater-than-or-equal",
+    "state_write": "compare-and-swap-on-revision",
+    "idempotent_replay": "same-key-and-exact-reviewed-input-only",
+    "reviewed_input_fields": ["archive_sha256", "source_proof_id", "source_proof_sha256"],
+    "promotion_order": [
+      "compare-ready-state-and-revision",
+      "match-release-and-reviewed-input",
+      "promote-blob",
+      "publish-signed-resolver-metadata",
+      "commit-active-state-and-audit"
+    ]
+  },
+  "promotion_trace_cases": [
+    {
+      "name": "public-delay-exact-72-hour-boundary",
+      "initial": {
+        "state": {"lifecycle": "delayed", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 7,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": null,
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "begin-second-scan",
+          "at": "2026-07-16T12:00:00Z",
+          "expected_revision": 7,
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "applied"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "second-scanning", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 8,
+        "promotion_count": 0
+      }
+    },
+    {
+      "name": "public-delay-one-second-before-boundary",
+      "initial": {
+        "state": {"lifecycle": "delayed", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 7,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": null,
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "begin-second-scan",
+          "at": "2026-07-16T11:59:59Z",
+          "expected_revision": 7,
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "denied",
+          "error_code": "public_delay_not_elapsed"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "delayed", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 7,
+        "promotion_count": 0
+      }
+    },
+    {
+      "name": "double-promotion-is-one-idempotent-write",
+      "initial": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 20,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:05:00Z",
+          "expected_revision": 20,
+          "idempotency_key": "promote-acme-http-1-2-3",
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "applied"
+        },
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:05:01Z",
+          "expected_revision": 20,
+          "idempotency_key": "promote-acme-http-1-2-3",
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "replayed"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "active", "visibility": "public", "availability": "available", "retention": "retained"},
+        "revision": 21,
+        "promotion_count": 1
+      }
+    },
+    {
+      "name": "concurrent-promotion-state-race-uses-cas",
+      "initial": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 30,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:06:00Z",
+          "expected_revision": 30,
+          "idempotency_key": "promote-racer-a",
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "applied"
+        },
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:06:00Z",
+          "expected_revision": 30,
+          "idempotency_key": "promote-racer-b",
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "cas-conflict",
+          "error_code": "release_state_changed"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "active", "visibility": "public", "availability": "available", "retention": "retained"},
+        "revision": 31,
+        "promotion_count": 1
+      }
+    },
+    {
+      "name": "promotion-rejects-unreviewed-archive",
+      "initial": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 40,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:07:00Z",
+          "expected_revision": 40,
+          "idempotency_key": "promote-unreviewed-archive",
+          "input": {
+            "archive_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+            "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "expected": "denied",
+          "error_code": "promotion_input_mismatch"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 40,
+        "promotion_count": 0
+      }
+    },
+    {
+      "name": "promotion-rejects-unreviewed-source-proof",
+      "initial": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 50,
+        "public_delay_started_at": "2026-07-13T12:00:00Z",
+        "release_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "reviewed_input": {
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+          "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "promoted_input": null,
+        "promotion_idempotency_key": null,
+        "promotion_count": 0
+      },
+      "operations": [
+        {
+          "kind": "promote",
+          "at": "2026-07-16T12:08:00Z",
+          "expected_revision": 50,
+          "idempotency_key": "promote-unreviewed-proof",
+          "input": {
+            "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_proof_id": "prf_01JZXDIFFERENTPROOF0001",
+            "source_proof_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+          },
+          "expected": "denied",
+          "error_code": "promotion_input_mismatch"
+        }
+      ],
+      "final": {
+        "state": {"lifecycle": "ready", "visibility": "public", "availability": "unavailable", "retention": "retained"},
+        "revision": 50,
+        "promotion_count": 0
+      }
+    }
+  ],
   "immutable_with_archive_digest": [
     "package",
     "version",

--- a/contracts/package-registry/v1/fixtures/scan-attestation-failure-cases-v1.json
+++ b/contracts/package-registry/v1/fixtures/scan-attestation-failure-cases-v1.json
@@ -1,0 +1,105 @@
+{
+  "contract_version": 1,
+  "base_attestation": "scan-attestation-v1.json",
+  "schema": "../schemas/scan-attestation-v1.schema.json",
+  "trusted_release": {
+    "package": "acme/http",
+    "version": "1.2.3",
+    "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+    "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "failure_mode": "remain-unavailable-retain-audit-and-retry-from-delayed",
+  "cases": [
+    {
+      "name": "scanner-crash",
+      "mutations": [
+        {"op": "replace", "path": "/result/status", "value": "error"},
+        {"op": "replace", "path": "/result/reason", "value": "scanner-crash"},
+        {"op": "replace", "path": "/result/disposition", "value": "retry-unavailable"},
+        {"op": "replace", "path": "/result/report_sha256", "value": null}
+      ],
+      "validation": "semantic-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_scanner_crash",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "scanner-timeout",
+      "mutations": [
+        {"op": "replace", "path": "/result/status", "value": "timeout"},
+        {"op": "replace", "path": "/result/reason", "value": "scanner-timeout"},
+        {"op": "replace", "path": "/result/disposition", "value": "retry-unavailable"},
+        {"op": "replace", "path": "/result/report_sha256", "value": null}
+      ],
+      "validation": "semantic-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_scanner_timeout",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "scan-result-missing",
+      "mutations": [
+        {"op": "remove", "path": "/result"}
+      ],
+      "validation": "schema-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_result_missing",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "observed-archive-digest-missing",
+      "mutations": [
+        {"op": "remove", "path": "/result/observed_archive_sha256"}
+      ],
+      "validation": "schema-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_archive_digest_missing",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "observed-source-proof-digest-missing",
+      "mutations": [
+        {"op": "remove", "path": "/result/observed_source_proof_sha256"}
+      ],
+      "validation": "schema-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_source_proof_digest_missing",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "observed-archive-digest-inconsistent",
+      "mutations": [
+        {"op": "replace", "path": "/result/observed_archive_sha256", "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}
+      ],
+      "validation": "semantic-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_archive_digest_mismatch",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    },
+    {
+      "name": "observed-source-proof-digest-inconsistent",
+      "mutations": [
+        {"op": "replace", "path": "/result/observed_source_proof_sha256", "value": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+      ],
+      "validation": "semantic-reject",
+      "expected": "retry-unavailable",
+      "error_code": "scan_source_proof_digest_mismatch",
+      "public_error_code": "temporarily_unavailable",
+      "next_lifecycle": "delayed",
+      "publicly_visible": false
+    }
+  ]
+}

--- a/contracts/package-registry/v1/fixtures/scan-attestation-v1.json
+++ b/contracts/package-registry/v1/fixtures/scan-attestation-v1.json
@@ -1,0 +1,58 @@
+{
+  "contract_version": 1,
+  "attestation_type": "seen-package-scan",
+  "attestation_id": "scn_01JZX9M1N2P3Q4R5S6T7",
+  "sequence": 2,
+  "previous_attestation_id": "scn_01JZX8A1B2C3D4E5F6G7",
+  "subject": {
+    "package": "acme/http",
+    "version": "1.2.3",
+    "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+    "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "scan": {
+    "phase": "second",
+    "attempt": 1,
+    "policy_version": "package-scan-v1.0.0",
+    "ruleset_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "scanner": {
+    "id": "seen-package-scanner",
+    "version": "1.0.0",
+    "isolated": true,
+    "network_access": "none",
+    "secret_access": "none",
+    "input_access": "read-only"
+  },
+  "input": {
+    "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "read_only": true
+  },
+  "sandbox": {
+    "rootless": true,
+    "ephemeral": true,
+    "network_access": "none",
+    "cpu_limit_millis": 2000,
+    "memory_limit_bytes": 536870912,
+    "process_limit": 64
+  },
+  "invocation": {
+    "id": "scan-run-acme-http-second-0001",
+    "started_at": "2026-07-16T12:00:00Z",
+    "finished_at": "2026-07-16T12:00:30Z",
+    "timeout_seconds": 300
+  },
+  "result": {
+    "status": "passed",
+    "reason": null,
+    "disposition": "promotion-eligible",
+    "observed_archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "observed_source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "findings": [],
+    "report_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "evidence_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "generated_at": "2026-07-16T12:00:31Z"
+}

--- a/contracts/package-registry/v1/fixtures/source-proof-failure-cases.json
+++ b/contracts/package-registry/v1/fixtures/source-proof-failure-cases.json
@@ -34,6 +34,15 @@
       ],
       "expected": "schema-reject",
       "error_code": "source_proof_verified_at_required"
+    },
+    {
+      "name": "mutable-ref-resolves-to-different-commit",
+      "description": "A ref re-resolved after review cannot replace the immutable commit bound by the trusted verification context.",
+      "mutations": [
+        {"op": "replace", "path": "/commit/value", "value": "fedcba9876543210fedcba9876543210fedcba98"}
+      ],
+      "expected": "semantic-reject",
+      "error_code": "source_proof_mutable_ref_changed"
     }
   ]
 }

--- a/contracts/package-registry/v1/openapi.yaml
+++ b/contracts/package-registry/v1/openapi.yaml
@@ -6,8 +6,8 @@ info:
   summary: Versioned package publication and retrieval contract
   description: |
     Host-neutral HTTP contract for Seen package metadata, immutable release
-    reservation, archive ingestion, release-state actions, source-proof
-    history, and archive download.
+    reservation, archive ingestion, release-state actions, source-proof and
+    scan-attestation history, and archive download.
 
     Package identity, release state, source provenance, registry authorization,
     and account authentication are separate concerns. Aether issues and manages
@@ -2003,6 +2003,8 @@ components:
       $ref: ./schemas/release-record.schema.json
     SourceProof:
       $ref: ./schemas/source-proof.schema.json
+    ScanAttestation:
+      $ref: ./schemas/scan-attestation-v1.schema.json
     ErrorEnvelope:
       $ref: ./schemas/error-envelope.schema.json
     ParsedManifest:

--- a/contracts/package-registry/v1/schemas/scan-attestation-v1.schema.json
+++ b/contracts/package-registry/v1/schemas/scan-attestation-v1.schema.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:seen:package-registry:v1:scan-attestation",
+  "title": "Seen package scan attestation v1",
+  "description": "An append-only record binding one isolated scan result to the exact immutable release archive and source proof reviewed by the scanner.",
+  "x-seen-semantic-rules": {
+    "evaluation": "all-rules-must-pass-before-ready-or-promotion",
+    "failure_reporting": "first-failing-rule-in-array-order",
+    "rules": [
+      {
+        "id": "invocation-time-order",
+        "operator": "rfc3339-less-than-or-equal",
+        "left_pointer": "/invocation/started_at",
+        "right_pointer": "/invocation/finished_at",
+        "error_code": "scan_invalid_time_order"
+      },
+      {
+        "id": "generation-after-invocation",
+        "operator": "rfc3339-less-than-or-equal",
+        "left_pointer": "/invocation/finished_at",
+        "right_pointer": "/generated_at",
+        "error_code": "scan_invalid_time_order"
+      },
+      {
+        "id": "mounted-archive-binding",
+        "operator": "json-pointer-equality",
+        "left_pointer": "/input/archive_sha256",
+        "right_pointer": "/subject/archive_sha256",
+        "error_code": "scan_archive_digest_mismatch"
+      },
+      {
+        "id": "observed-archive-binding",
+        "operator": "json-pointer-equality",
+        "left_pointer": "/result/observed_archive_sha256",
+        "right_pointer": "/subject/archive_sha256",
+        "error_code": "scan_archive_digest_mismatch"
+      },
+      {
+        "id": "mounted-source-proof-binding",
+        "operator": "json-pointer-equality",
+        "left_pointer": "/input/source_proof_sha256",
+        "right_pointer": "/subject/source_proof_sha256",
+        "error_code": "scan_source_proof_digest_mismatch"
+      },
+      {
+        "id": "observed-source-proof-binding",
+        "operator": "json-pointer-equality",
+        "left_pointer": "/result/observed_source_proof_sha256",
+        "right_pointer": "/subject/source_proof_sha256",
+        "error_code": "scan_source_proof_digest_mismatch"
+      },
+      {
+        "id": "trusted-release-archive-binding",
+        "operator": "json-pointer-equals-trusted-context",
+        "left_pointer": "/subject/archive_sha256",
+        "context_pointer": "/release/archive/sha256",
+        "error_code": "scan_archive_digest_mismatch"
+      },
+      {
+        "id": "trusted-release-source-proof-binding",
+        "operator": "json-pointer-equals-trusted-context",
+        "left_pointer": "/subject/source_proof_sha256",
+        "context_pointer": "/release/source_proof_sha256",
+        "error_code": "scan_source_proof_digest_mismatch"
+      },
+      {
+        "id": "trusted-release-source-proof-id-binding",
+        "operator": "json-pointer-equals-trusted-context",
+        "left_pointer": "/subject/source_proof_id",
+        "context_pointer": "/release/source_proof_id",
+        "error_code": "scan_source_proof_id_mismatch"
+      },
+      {
+        "id": "promotion-requires-passed-result",
+        "operator": "status-disposition-pair",
+        "passed_status": "passed",
+        "eligible_disposition": "promotion-eligible",
+        "error_code": "scan_result_not_passed"
+      }
+    ]
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "attestation_type",
+    "attestation_id",
+    "sequence",
+    "previous_attestation_id",
+    "subject",
+    "scan",
+    "scanner",
+    "input",
+    "sandbox",
+    "invocation",
+    "result",
+    "generated_at"
+  ],
+  "properties": {
+    "contract_version": {"const": 1},
+    "attestation_type": {"const": "seen-package-scan"},
+    "attestation_id": {"$ref": "#/$defs/attestationId"},
+    "sequence": {"type": "integer", "minimum": 1},
+    "previous_attestation_id": {
+      "oneOf": [
+        {"$ref": "#/$defs/attestationId"},
+        {"type": "null"}
+      ]
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["package", "version", "archive_sha256", "source_proof_id", "source_proof_sha256"],
+      "properties": {
+        "package": {"$ref": "#/$defs/packageIdentity"},
+        "version": {"$ref": "#/$defs/exactVersion"},
+        "archive_sha256": {"$ref": "#/$defs/sha256"},
+        "source_proof_id": {"type": "string", "pattern": "^prf_[A-Za-z0-9_-]{16,96}$"},
+        "source_proof_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["phase", "attempt", "policy_version", "ruleset_sha256"],
+      "properties": {
+        "phase": {"enum": ["first", "second"]},
+        "attempt": {"type": "integer", "minimum": 1},
+        "policy_version": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]{0,63}$"},
+        "ruleset_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scanner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version",
+        "isolated",
+        "network_access",
+        "secret_access",
+        "input_access"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{2,63}$"},
+        "version": {"type": "string", "pattern": "^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$"},
+        "isolated": {"const": true},
+        "network_access": {"const": "none"},
+        "secret_access": {"const": "none"},
+        "input_access": {"const": "read-only"}
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["archive_sha256", "source_proof_sha256", "read_only"],
+      "properties": {
+        "archive_sha256": {"$ref": "#/$defs/sha256"},
+        "source_proof_sha256": {"$ref": "#/$defs/sha256"},
+        "read_only": {"const": true}
+      }
+    },
+    "sandbox": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rootless",
+        "ephemeral",
+        "network_access",
+        "cpu_limit_millis",
+        "memory_limit_bytes",
+        "process_limit"
+      ],
+      "properties": {
+        "rootless": {"const": true},
+        "ephemeral": {"const": true},
+        "network_access": {"const": "none"},
+        "cpu_limit_millis": {"type": "integer", "minimum": 1},
+        "memory_limit_bytes": {"type": "integer", "minimum": 1048576},
+        "process_limit": {"type": "integer", "minimum": 1}
+      }
+    },
+    "invocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "started_at", "finished_at", "timeout_seconds"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^scan-run-[a-z0-9-]{8,96}$"},
+        "started_at": {"$ref": "#/$defs/utcTimestamp"},
+        "finished_at": {"$ref": "#/$defs/utcTimestamp"},
+        "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 3600}
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "reason",
+        "disposition",
+        "observed_archive_sha256",
+        "observed_source_proof_sha256",
+        "findings",
+        "report_sha256",
+        "evidence_sha256"
+      ],
+      "properties": {
+        "status": {"enum": ["passed", "failed", "error", "timeout"]},
+        "reason": {
+          "oneOf": [
+            {"type": "null"},
+            {"enum": ["policy-violation", "scanner-inconclusive", "scanner-crash", "scanner-timeout"]}
+          ]
+        },
+        "disposition": {"enum": ["promotion-eligible", "reject", "retry-unavailable"]},
+        "observed_archive_sha256": {"$ref": "#/$defs/sha256"},
+        "observed_source_proof_sha256": {"$ref": "#/$defs/sha256"},
+        "findings": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["rule_id", "severity", "code", "path"],
+            "properties": {
+              "rule_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]{1,95}$"},
+              "severity": {"enum": ["info", "low", "medium", "high", "critical"]},
+              "code": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_]{2,95}$"},
+              "path": {
+                "oneOf": [
+                  {"type": "string", "maxLength": 240},
+                  {"type": "null"}
+                ]
+              }
+            }
+          }
+        },
+        "report_sha256": {
+          "oneOf": [
+            {"$ref": "#/$defs/sha256"},
+            {"type": "null"}
+          ]
+        },
+        "evidence_sha256": {
+          "description": "SHA-256 of the immutable scanner evidence bundle retained with this attestation.",
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"status": {"const": "passed"}}, "required": ["status"]},
+          "then": {
+            "properties": {
+              "reason": {"type": "null"},
+              "disposition": {"const": "promotion-eligible"},
+              "report_sha256": {"$ref": "#/$defs/sha256"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"status": {"const": "failed"}}, "required": ["status"]},
+          "then": {
+            "properties": {
+              "reason": {"const": "policy-violation"},
+              "disposition": {"const": "reject"},
+              "report_sha256": {"$ref": "#/$defs/sha256"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"status": {"const": "error"}}, "required": ["status"]},
+          "then": {
+            "properties": {
+              "reason": {"enum": ["scanner-inconclusive", "scanner-crash"]},
+              "disposition": {"const": "retry-unavailable"},
+              "report_sha256": {"type": "null"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"status": {"const": "timeout"}}, "required": ["status"]},
+          "then": {
+            "properties": {
+              "reason": {"const": "scanner-timeout"},
+              "disposition": {"const": "retry-unavailable"},
+              "report_sha256": {"type": "null"}
+            }
+          }
+        }
+      ]
+    },
+    "generated_at": {"$ref": "#/$defs/utcTimestamp"}
+  },
+  "$defs": {
+    "packageIdentity": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 127,
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+    },
+    "attestationId": {
+      "type": "string",
+      "pattern": "^scn_[A-Za-z0-9_-]{16,96}$"
+    },
+    "exactVersion": {
+      "type": "string",
+      "format": "semver-exact",
+      "maxLength": 128,
+      "pattern": "^(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$"
+    }
+  }
+}

--- a/contracts/package-registry/v1/schemas/source-proof.schema.json
+++ b/contracts/package-registry/v1/schemas/source-proof.schema.json
@@ -3,6 +3,30 @@
   "$id": "urn:seen:package-registry:v1:source-proof",
   "title": "Seen package registry source proof v1",
   "description": "An append-only verification record binding a package archive to an immutable forge repository and commit.",
+  "x-seen-semantic-rules": {
+    "evaluation": "all-rules-must-pass-at-verification-and-each-pre-activation-recheck",
+    "failure_reporting": "first-failing-rule-in-array-order",
+    "rules": [
+      {
+        "id": "immutable-ref-resolution",
+        "operator": "repository-requested-ref-resolved-ref-and-commit-equal-trusted-verification-context",
+        "document_pointers": [
+          "/repository",
+          "/requested_ref",
+          "/resolved_ref",
+          "/commit"
+        ],
+        "error_code": "source_proof_mutable_ref_changed"
+      },
+      {
+        "id": "archive-digest-binding",
+        "operator": "json-pointer-equals-trusted-context",
+        "left_pointer": "/archive/package_sha256",
+        "context_pointer": "/release/archive/sha256",
+        "error_code": "source_proof_archive_digest_mismatch"
+      }
+    ]
+  },
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -187,18 +187,21 @@ be selected by the package's `include` or `assets` patterns. Windows rejects
 `--token-file`; inject `SEEN_REGISTRY_TOKEN` through the trusted publisher
 process environment instead.
 
-The development service accepts the bound submission but keeps the release
-delayed, unavailable, and excluded from public catalog, resolution, and
-download. The CLI still reserves these inactive hosted operations:
+The development service accepts the bound submission as quarantined and
+unavailable. Successful immutable-source verification and the first isolated
+scan start the exact 72-hour public delay; a fresh source proof and second scan
+are required before promotion into catalog, resolution, and download metadata.
+The CLI still reserves these hosted operations:
 
 ```bash
 seen pkg login|logout|whoami [options]
 seen pkg yank|report [options]
 ```
 
-They and private-package access remain inactive in 0.10.0. The development read
-service and embedded trust root are live; production remains absent and fails
-closed.
+The service exposes authenticated report, yank, appeal, and emergency-security
+workflows, while their CLI commands and private-package access remain inactive
+in 0.10.0. The development service and embedded trust root are live; production
+remains absent and fails closed.
 
 ### Platform Packaging Commands
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -118,7 +118,7 @@ seen pkg add|remove|fetch|update [options]
 seen pkg tree [--lock <Seen.lock>]
 seen pkg audit [--lock <Seen.lock>]
 seen pkg pack [options]
-seen pkg publish [project-dir-or-manifest] [--registry <origin>] [--token-file <mode-0600-file>] [source options]
+seen pkg publish [project-dir-or-manifest] [--registry <origin>] [--token-file <mode-0600-file>] [--source-forge github|gitlab] [source options]
 seen pkg prebuild [project-dir-or-manifest] [output-dir]
 ```
 
@@ -131,8 +131,9 @@ seen pkg prebuild [project-dir-or-manifest] [output-dir]
   explicit lock path.
 - `pack` creates a validated source archive for the current package.
 - `publish` submits a source package with an authorized internal credential and
-  bound source repository, installation, ref, commit, and SPDX license
-  metadata. Development submissions complete as delayed and unavailable.
+  bound source forge, repository, installation, ref, commit, and SPDX license
+  metadata. Development submissions complete as quarantined and unavailable;
+  the public delay begins only after source verification and the first scan pass.
 - `prebuild` emits a local prebuilt artifact containing `Seen.pkg.toml`,
   `objects.tsv`, `interface.index.tsv`, object files, and interface sources.
 
@@ -169,12 +170,17 @@ Controlled internal publishing is available through:
 ```bash
 seen pkg publish [project-dir-or-manifest] \
   --token-file <mode-0600-file> \
+  --source-forge github \
   --source-repository-id <id> \
   --source-installation-id <id> \
   --source-ref refs/heads/<branch> \
   --source-commit <full-commit> \
   --license-spdx <identifier>
 ```
+
+`--source-forge` accepts exactly `github` or `gitlab`. The equivalent
+`SEEN_SOURCE_FORGE` environment variable has the same validation and defaults
+to `github` when neither form is supplied.
 
 On Linux and macOS, a token file must be one private regular file and must not
 be selected by the package's `include` or `assets` patterns. Windows rejects

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -253,19 +253,21 @@ the package client. Production later promotes the same host-neutral contract to
 delegated signing identities, and routing—not by rewriting package or schema
 identities. Production is not deployed and has no embedded root.
 
-Controlled internal publishing is active in development, but submitted releases
-remain delayed and unavailable. They do not enter public catalog metadata,
-resolution, or downloads until promotion is implemented. Hosted account
-operations, private-package access, yanking, and reporting remain inactive.
+Controlled internal publishing is active in development. Submissions complete
+as quarantined and unavailable; immutable-source verification and a successful
+first isolated scan begin the exact 72-hour public delay. Activation requires a
+fresh source proof, a second successful scan, and exact-digest promotion. Hosted
+account operations and private-package access remain inactive; authenticated
+report, appeal, yank, and emergency-security service endpoints are available.
 
 ## Current Limits
 
 - The development registry and embedded official root are active; production
   remains absent and fails closed without an embedded root.
-- Submitted releases remain delayed, unavailable, and invisible to catalog,
-  resolution, and downloads until promotion work lands.
-- Hosted login/account flows, private packages, yanking, and reporting are
-  inactive; publishing is restricted to controlled internal credentials.
+- Submitted releases remain quarantined or delayed, unavailable, and invisible
+  to catalog, resolution, and downloads until every review gate passes.
+- Hosted login/account flows and private packages remain inactive; publishing
+  and enforcement mutations require controlled role-specific credentials.
 - Hosted URLs must use canonical HTTPS origins; plain HTTP, origin changes, and
   unsigned fallback metadata are rejected.
 - Prebuilt package artifacts are local path dependencies; registry publication

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -180,8 +180,11 @@ seen pkg prebuild [project-dir-or-manifest] [output-dir]
 graph, `update` performs fresh selection, `tree` prints the locked graph,
 `audit` validates lock graph/capability bindings and lists package digests, and
 `pack` creates a source archive. `publish` is restricted to controlled internal
-publisher credentials, requires source repository/install/ref/commit/license
-bindings, and returns a delayed, unavailable release. Unix token files must be
+publisher credentials, requires source
+forge/repository/install/ref/commit/license bindings, and returns a quarantined,
+unavailable release. The public delay begins only after source verification and
+the first scan pass. `--source-forge` (or `SEEN_SOURCE_FORGE`) accepts exactly
+`github` or `gitlab` and defaults to `github`. Unix token files must be
 private regular files outside the selected package content; Windows publishers
 use `SEEN_REGISTRY_TOKEN` from a trusted process environment. `prebuild` remains
 the separate local native-artifact workflow described below.

--- a/examples/registry-smoke/LICENSE
+++ b/examples/registry-smoke/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Seen Language Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/registry-smoke/README.md
+++ b/examples/registry-smoke/README.md
@@ -1,0 +1,25 @@
+# Development registry smoke package
+
+This source-only package is the immutable publish fixture for the development
+registry. Its archive contains the byte-exact `Seen.toml`, MIT license, and Seen
+source committed under this directory.
+
+Publish only after an immutable tag for the commit is available from GitHub. Bind the request
+to the repository's numeric GitHub ID, the numeric GitHub App installation ID,
+the full tag ref, and the exact 40-character commit ID:
+
+```bash
+seen pkg publish examples/registry-smoke \
+  --registry https://seen.dev.yousef.codes/packages \
+  --token-file <mode-0600-token-file-outside-this-directory> \
+  --source-forge github \
+  --source-repository-id <numeric-repository-id> \
+  --source-installation-id <numeric-installation-id> \
+  --source-ref refs/tags/registry-smoke-v0.1.1 \
+  --source-commit <full-commit-id> \
+  --license-spdx MIT \
+  --repository https://github.com/codeyousef/SeenLang
+```
+
+Do not edit, rebuild, or repack this version after publishing it. Bump the
+version before the next registry smoke submission.

--- a/examples/registry-smoke/Seen.toml
+++ b/examples/registry-smoke/Seen.toml
@@ -2,14 +2,14 @@ manifest-version = 1
 
 [project]
 name = "registry_smoke"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 repository = "https://github.com/codeyousef/SeenLang"
 
 [package]
 identity = "seen/registry-smoke"
 visibility = "public"
-include = ["src/**/*.seen"]
+include = ["src/**/*.seen", "LICENSE"]
 assets = []
 capabilities = []
 

--- a/tests/package_registry_contracts.py
+++ b/tests/package_registry_contracts.py
@@ -9,7 +9,7 @@ import re
 import tomllib
 import unicodedata
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -1251,6 +1251,28 @@ def parse_openapi_operations(openapi: str) -> dict[str, tuple[str, str, str]]:
     return operations
 
 
+def source_proof_semantic_error(
+    proof: dict[str, Any], trusted: dict[str, Any]
+) -> str | None:
+    if (
+        proof["package"] != trusted["package"]
+        or proof["version"] != trusted["version"]
+    ):
+        return "source_proof_release_identity_mismatch"
+    if proof["repository"] != trusted["repository"]:
+        return "source_proof_repository_mismatch"
+    if proof["requested_ref"] != trusted["requested_ref"]:
+        return "source_proof_requested_ref_mismatch"
+    if (
+        proof["resolved_ref"] != trusted["resolved_ref"]
+        or proof["commit"] != trusted["commit"]
+    ):
+        return "source_proof_mutable_ref_changed"
+    if proof["archive"] != trusted["archive"]:
+        return "source_proof_archive_digest_mismatch"
+    return None
+
+
 def check_api_contracts() -> None:
     for schema_name, fixture_name in (
         ("package-record.schema.json", "package-record-v1.json"),
@@ -1288,12 +1310,28 @@ def check_api_contracts() -> None:
     assert all(check["status"] == "passed" for check in proof["checks"])
 
     proof_schema = load_json("schemas/source-proof.schema.json")
+    proof_semantic_rules = proof_schema["x-seen-semantic-rules"]["rules"]
+    assert any(
+        rule["error_code"] == "source_proof_mutable_ref_changed"
+        for rule in proof_semantic_rules
+    )
     proof_failures = load_json("fixtures/source-proof-failure-cases.json")
     assert proof_failures["base_source_proof"] == "source-proof-v1.json"
     for case in proof_failures["invalid_cases"]:
         invalid = apply_json_mutations(proof, case["mutations"])
-        assert schema_errors(invalid, proof_schema, proof_schema), case["name"]
-        assert case["expected"] == "schema-reject"
+        failures = schema_errors(invalid, proof_schema, proof_schema)
+        if case["expected"] == "schema-reject":
+            assert failures, case["name"]
+        else:
+            assert case["expected"] == "semantic-reject", case["name"]
+            assert not failures, f"{case['name']}: {failures}"
+            assert (
+                source_proof_semantic_error(invalid, proof) == case["error_code"]
+            ), case["name"]
+    assert any(
+        case["error_code"] == "source_proof_mutable_ref_changed"
+        for case in proof_failures["invalid_cases"]
+    )
 
     error_schema = load_json("schemas/error-envelope.schema.json")
     errors_fixture = load_json("fixtures/api-error-cases-v1.json")
@@ -1586,6 +1624,10 @@ def check_archive_contracts() -> None:
         "absolute",
         "symlink",
         "device",
+        "fifo",
+        "socket",
+        "sparse",
+        "unknown",
         "collision",
         "bomb",
         "executable",
@@ -1598,6 +1640,13 @@ def check_archive_contracts() -> None:
         "package manager state",
     ):
         assert required in coverage, f"missing hostile archive case: {required}"
+    covered_forbidden_types = {
+        entry["type"]
+        for case in fixture["cases"]
+        if case["expected"] == "reject"
+        for entry in case["archive"]["entries"]
+    }
+    assert set(entry_rules["forbidden_types"]) <= covered_forbidden_types
 
     binding_fixture = load_json("fixtures/manifest-archive-binding-cases-v1.json")
     assert binding_fixture["comparison"] == (
@@ -2196,7 +2245,9 @@ def provenance_semantic_error(
     finished = datetime.fromisoformat(
         attestation["invocation"]["finished_at"].replace("Z", "+00:00")
     )
-    generated = datetime.fromisoformat(attestation["generated_at"].replace("Z", "+00:00"))
+    generated = datetime.fromisoformat(
+        attestation["generated_at"].replace("Z", "+00:00")
+    )
     if not started <= finished <= generated:
         return "provenance_invalid_time_order"
     if attestation["invocation"]["reproducible"] is not True:
@@ -2234,6 +2285,111 @@ def check_provenance_contracts() -> None:
         else:
             assert observed == case["error_code"], case["name"]
         assert case["expected"] == "reject"
+
+
+def scan_attestation_semantic_error(
+    attestation: dict[str, Any], trusted: dict[str, Any]
+) -> str | None:
+    started = datetime.fromisoformat(
+        attestation["invocation"]["started_at"].replace("Z", "+00:00")
+    )
+    finished = datetime.fromisoformat(
+        attestation["invocation"]["finished_at"].replace("Z", "+00:00")
+    )
+    generated = datetime.fromisoformat(attestation["generated_at"].replace("Z", "+00:00"))
+    if not started <= finished <= generated:
+        return "scan_invalid_time_order"
+    subject = attestation["subject"]
+    if (
+        subject["package"] != trusted["package"]
+        or subject["version"] != trusted["version"]
+    ):
+        return "scan_release_identity_mismatch"
+    if (
+        subject["archive_sha256"] != trusted["archive_sha256"]
+        or attestation["input"]["archive_sha256"] != subject["archive_sha256"]
+        or attestation["result"]["observed_archive_sha256"]
+        != subject["archive_sha256"]
+    ):
+        return "scan_archive_digest_mismatch"
+    if subject["source_proof_id"] != trusted["source_proof_id"]:
+        return "scan_source_proof_id_mismatch"
+    if (
+        subject["source_proof_sha256"] != trusted["source_proof_sha256"]
+        or attestation["input"]["source_proof_sha256"]
+        != subject["source_proof_sha256"]
+        or attestation["result"]["observed_source_proof_sha256"]
+        != subject["source_proof_sha256"]
+    ):
+        return "scan_source_proof_digest_mismatch"
+    result = attestation["result"]
+    if result["status"] == "error":
+        return {
+            "scanner-inconclusive": "scan_inconclusive",
+            "scanner-crash": "scan_scanner_crash",
+        }[result["reason"]]
+    if result["status"] == "timeout":
+        return "scan_scanner_timeout"
+    if result["status"] == "failed":
+        return "scan_policy_failed"
+    if result["status"] != "passed" or result["disposition"] != "promotion-eligible":
+        return "scan_result_not_passed"
+    return None
+
+
+def check_scan_attestation_contracts() -> None:
+    schema = load_json("schemas/scan-attestation-v1.schema.json")
+    base = load_json("fixtures/scan-attestation-v1.json")
+    errors = schema_errors(base, schema, schema)
+    assert not errors, errors
+    assert base["scan"]["phase"] in {"first", "second"}
+    assert re.fullmatch(r"[0-9a-f]{64}", base["scan"]["ruleset_sha256"])
+    assert base["subject"]["source_proof_id"].startswith("prf_")
+    assert base["scanner"] == {
+        "id": "seen-package-scanner",
+        "version": "1.0.0",
+        "isolated": True,
+        "network_access": "none",
+        "secret_access": "none",
+        "input_access": "read-only",
+    }
+    assert base["input"]["read_only"] is True
+    assert isinstance(base["result"]["findings"], list)
+    assert re.fullmatch(r"[0-9a-f]{64}", base["result"]["evidence_sha256"])
+
+    failure_fixture = load_json("fixtures/scan-attestation-failure-cases-v1.json")
+    assert failure_fixture["base_attestation"] == "scan-attestation-v1.json"
+    trusted = failure_fixture["trusted_release"]
+    assert scan_attestation_semantic_error(base, trusted) is None
+    names = [case["name"] for case in failure_fixture["cases"]]
+    assert len(names) == len(set(names))
+    for case in failure_fixture["cases"]:
+        mutated = apply_json_mutations(base, case["mutations"])
+        failures = schema_errors(mutated, schema, schema)
+        if case["validation"] == "schema-reject":
+            assert failures, case["name"]
+        else:
+            assert case["validation"] == "semantic-reject", case["name"]
+            assert not failures, f"{case['name']}: {failures}"
+            assert (
+                scan_attestation_semantic_error(mutated, trusted)
+                == case["error_code"]
+            ), case["name"]
+        assert case["expected"] == "retry-unavailable", case["name"]
+        assert case["public_error_code"] == "temporarily_unavailable", case["name"]
+        assert case["next_lifecycle"] == "delayed", case["name"]
+        assert case["publicly_visible"] is False, case["name"]
+    coverage = " ".join(names)
+    for required in (
+        "scanner-crash",
+        "scanner-timeout",
+        "scan-result-missing",
+        "archive-digest-missing",
+        "source-proof-digest-missing",
+        "archive-digest-inconsistent",
+        "source-proof-digest-inconsistent",
+    ):
+        assert required in coverage, f"missing scan failure case: {required}"
 
 
 def transition_matches(
@@ -2305,6 +2461,105 @@ def apply_trace_step(
         state.update(next_state)
         return True
     return False
+
+
+def apply_promotion_operation(
+    protocol: dict[str, Any], record: dict[str, Any], operation: dict[str, Any]
+) -> tuple[str, str | None]:
+    at = datetime.fromisoformat(operation["at"].replace("Z", "+00:00"))
+    input_binding = operation["input"]
+    if operation["kind"] == "begin-second-scan":
+        if operation["expected_revision"] != record["revision"]:
+            return "cas-conflict", "release_state_changed"
+        if input_binding != record["release_input"]:
+            return "denied", "promotion_input_mismatch"
+        if record["state"]["lifecycle"] != "delayed":
+            return "denied", "state_transition_forbidden"
+        delay_started = datetime.fromisoformat(
+            record["public_delay_started_at"].replace("Z", "+00:00")
+        )
+        delay_ends = delay_started + timedelta(seconds=protocol["public_delay_seconds"])
+        if at < delay_ends:
+            return "denied", "public_delay_not_elapsed"
+        record["state"]["lifecycle"] = "second-scanning"
+        record["revision"] += 1
+        return "applied", None
+
+    assert operation["kind"] == "promote", operation["kind"]
+    if (
+        input_binding != record["release_input"]
+        or input_binding != record["reviewed_input"]
+    ):
+        return "denied", "promotion_input_mismatch"
+    if (
+        record["state"]["lifecycle"] == "active"
+        and operation["idempotency_key"] == record["promotion_idempotency_key"]
+        and input_binding == record["promoted_input"]
+    ):
+        return "replayed", None
+    if operation["expected_revision"] != record["revision"]:
+        return "cas-conflict", "release_state_changed"
+    if record["state"] != {
+        "lifecycle": "ready",
+        "visibility": "public",
+        "availability": "unavailable",
+        "retention": "retained",
+    }:
+        return "denied", "release_not_ready"
+    record["promoted_input"] = deepcopy(input_binding)
+    record["promotion_idempotency_key"] = operation["idempotency_key"]
+    record["promotion_count"] += 1
+    record["state"]["lifecycle"] = "active"
+    record["state"]["availability"] = "available"
+    record["revision"] += 1
+    return "applied", None
+
+
+def check_promotion_traces(fixture: dict[str, Any]) -> None:
+    protocol = fixture["promotion_protocol"]
+    assert protocol["server_clock"] == "rfc3339-utc"
+    assert protocol["public_delay_seconds"] == 72 * 60 * 60
+    assert protocol["delay_comparison"] == "elapsed-greater-than-or-equal"
+    assert protocol["state_write"] == "compare-and-swap-on-revision"
+    assert protocol["reviewed_input_fields"] == [
+        "archive_sha256",
+        "source_proof_id",
+        "source_proof_sha256",
+    ]
+    cases = fixture["promotion_trace_cases"]
+    names = [case["name"] for case in cases]
+    assert len(names) == len(set(names))
+    for case in cases:
+        record = deepcopy(case["initial"])
+        assert state_satisfies_invariants(fixture, record["state"]), case["name"]
+        assert record["promotion_count"] == 0, case["name"]
+        assert set(record["release_input"]) == set(protocol["reviewed_input_fields"])
+        assert record["release_input"]["source_proof_id"].startswith("prf_")
+        if record["state"]["lifecycle"] == "ready":
+            assert record["reviewed_input"] == record["release_input"], case["name"]
+        for operation in case["operations"]:
+            assert set(operation["input"]) == set(protocol["reviewed_input_fields"])
+            outcome, error_code = apply_promotion_operation(
+                protocol, record, operation
+            )
+            assert outcome == operation["expected"], case["name"]
+            assert error_code == operation.get("error_code"), case["name"]
+        for key, value in case["final"].items():
+            assert record[key] == value, case["name"]
+        assert record["promotion_count"] <= 1, case["name"]
+        if record["promotion_count"]:
+            assert record["promoted_input"] == record["reviewed_input"], case["name"]
+            assert record["promoted_input"] == record["release_input"], case["name"]
+    coverage = " ".join(names)
+    for required in (
+        "exact-72-hour-boundary",
+        "one-second-before-boundary",
+        "double-promotion",
+        "state-race",
+        "unreviewed-archive",
+        "unreviewed-source-proof",
+    ):
+        assert required in coverage, f"missing promotion trace: {required}"
 
 
 def check_release_transitions() -> None:
@@ -2386,6 +2641,52 @@ def check_release_transitions() -> None:
                 assert state == case["final"], case["name"]
         else:
             assert failure_step == case["failure_step"], case["name"]
+    check_promotion_traces(fixture)
+
+
+def positive_safe_claims(text: str) -> list[str]:
+    patterns = (
+        re.compile(
+            r"\b(?:package|release)s?(?:\s+[a-z-]+){0,3}\s+"
+            r"(?:is|are|was|were|be|been|marked|certified|considered)\s+"
+            r"(?:as\s+)?safe\b",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\bsafe\s+(?:package|release)s?\b", re.IGNORECASE),
+    )
+    claims: list[str] = []
+    for pattern in patterns:
+        for match in pattern.finditer(text):
+            prefix = text[max(0, match.start() - 96) : match.start()].lower()
+            if re.search(
+                r"\b(?:(?:must\s+)?never|must\s+not|do\s+not|does\s+not|cannot)\s+"
+                r"(?:claim|say|state|call|describe|label|mark|certify|mean|guarantee)"
+                r"[^.\n]{0,64}$",
+                prefix,
+            ):
+                continue
+            claims.append(match.group(0))
+    return claims
+
+
+def check_public_wording() -> None:
+    surfaces = [
+        CONTRACT / "README.md",
+        CONTRACT / "openapi.yaml",
+        CONTRACT / "fixtures" / "api-error-cases-v1.json",
+        CONTRACT / "fixtures" / "package-record-v1.json",
+        CONTRACT / "fixtures" / "release-record-v1.json",
+        ROOT / "README.md",
+        ROOT / "docs" / "cli-reference.md",
+        ROOT / "docs" / "packaging.md",
+        ROOT / "docs" / "known-limitations.md",
+        *sorted((ROOT / "tools" / "seen-pkg" / "internal" / "commands").glob("*.go")),
+    ]
+    for surface in surfaces:
+        claims = positive_safe_claims(surface.read_text(encoding="utf-8"))
+        assert not claims, f"{surface.relative_to(ROOT)} makes a public safety claim: {claims}"
+    assert positive_safe_claims("This package is safe.") == ["package is safe"]
+    assert not positive_safe_claims("The dashboard must never say a package is safe.")
 
 
 def check_security_boundary() -> None:
@@ -2394,7 +2695,8 @@ def check_security_boundary() -> None:
     assert "normative v1" in readme
     assert "not yet the normative" not in readme
     assert "valid deterministic test signatures" in readme
-    assert "official origins fail closed" in readme
+    assert "official development root" in readme
+    assert re.search(r"production still\s+fails closed", readme)
     assert "Signing-key compromise" in threat_model
     table_rows = [
         line
@@ -2422,6 +2724,8 @@ def check_security_boundary() -> None:
     for row in table_rows[1:]:
         columns = [column.strip() for column in row.split("|")[1:-1]]
         assert len(columns) == 6 and all(columns), row
+
+
 def main() -> None:
     check_identities()
     check_manifest()
@@ -2435,7 +2739,9 @@ def main() -> None:
     check_archive_contracts()
     check_signing_contracts()
     check_provenance_contracts()
+    check_scan_attestation_contracts()
     check_release_transitions()
+    check_public_wording()
     check_security_boundary()
     print("PASS: Seen package registry v1 normative contracts and shared fixtures")
 

--- a/tools/seen-pkg/internal/commands/pack_test.go
+++ b/tools/seen-pkg/internal/commands/pack_test.go
@@ -4,12 +4,51 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	seenarchive "github.com/codeyousef/seen/tools/seen-pkg/internal/archive"
 	"github.com/codeyousef/seen/tools/seen-pkg/internal/manifest"
 	"github.com/codeyousef/seen/tools/seen-pkg/internal/model"
 )
+
+func TestRegistrySmokeFixtureIsFreshAndSourceProofReady(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "..", "examples", "registry-smoke")
+	parsed, err := manifest.Load(filepath.Join(root, "Seen.toml"), manifest.Options{
+		DefaultRegistryOrigin: "https://seen.dev.yousef.codes/packages",
+		RequireManifestV1:     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, document, err := parsedPublishManifest(parsed.Raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, _ := document["project"].(map[string]any)
+	if parsed.Project.Version != "0.1.1" || project["license"] != "MIT" ||
+		project["repository"] != "https://github.com/codeyousef/SeenLang" {
+		t.Fatalf("unexpected smoke project binding: %+v", project)
+	}
+	if parsed.Package == nil || parsed.Package.Identity != "seen/registry-smoke" ||
+		parsed.Package.Visibility != "public" {
+		t.Fatalf("unexpected smoke package binding: %+v", parsed.Package)
+	}
+	files, err := selectedPackageFiles(root, parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(files, "\n"), strings.Join([]string{
+		"LICENSE",
+		"Seen.toml",
+		"src/registry_smoke.seen",
+	}, "\n"); got != want {
+		t.Fatalf("smoke archive files:\n%s\nwant:\n%s", got, want)
+	}
+	if _, err := Pack(context.Background(), root, filepath.Join(t.TempDir(), "registry-smoke-0.1.1.seenpkg.tgz")); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestPackIsDeterministicAndSourceOnly(t *testing.T) {
 	t.Parallel()

--- a/tools/seen-pkg/internal/commands/publish.go
+++ b/tools/seen-pkg/internal/commands/publish.go
@@ -24,16 +24,18 @@ import (
 
 const (
 	defaultPublishOrigin      = "https://seen.dev.yousef.codes/packages"
+	defaultSourceForge        = "github"
 	maxAPIResponseBytes       = 4 * 1024 * 1024
 	maxPublishTokenFileBytes  = 4096
 	maximumArchiveUploadBytes = 25 * 1024 * 1024
 )
 
 type publishCLI struct {
-	ManifestPath, RegistryOrigin, TokenFile               string
-	RepositoryID, InstallationID, SourceRef, SourceCommit string
-	LicenseSPDX, Description, RepositoryURL               string
-	Quiet                                                 bool
+	ManifestPath, RegistryOrigin, TokenFile   string
+	SourceForge, RepositoryID, InstallationID string
+	SourceRef, SourceCommit                   string
+	LicenseSPDX, Description, RepositoryURL   string
+	Quiet                                     bool
 }
 
 type createPackageRequest struct {
@@ -190,7 +192,7 @@ func (backend *ProductionBackend) publish(ctx context.Context, arguments []strin
 		Archive:        publishArchive{Format: "tar+gzip", SHA256: packed.SHA256, CompressedBytes: packed.Length},
 		ManifestSHA256: manifestSHA256,
 		Manifest:       manifestJSON,
-		Source:         publishSource{Forge: "github", RepositoryID: cli.RepositoryID, InstallationID: cli.InstallationID, RequestedRef: cli.SourceRef, ExpectedCommit: cli.SourceCommit, LicenseSPDX: cli.LicenseSPDX},
+		Source:         publishSource{Forge: cli.SourceForge, RepositoryID: cli.RepositoryID, InstallationID: cli.InstallationID, RequestedRef: cli.SourceRef, ExpectedCommit: cli.SourceCommit, LicenseSPDX: cli.LicenseSPDX},
 	}
 	owner, name, _ := strings.Cut(parsed.Package.Identity, "/")
 	path := fmt.Sprintf("/api/v1/packages/%s/%s/releases", url.PathEscape(owner), url.PathEscape(name))
@@ -235,7 +237,7 @@ func (backend *ProductionBackend) publish(ctx context.Context, arguments []strin
 }
 
 func parsePublishCLI(arguments []string) (publishCLI, error) {
-	options := publishCLI{RegistryOrigin: envOr("SEEN_REGISTRY_ORIGIN", defaultPublishOrigin), TokenFile: os.Getenv("SEEN_REGISTRY_TOKEN_FILE"), RepositoryID: os.Getenv("SEEN_SOURCE_REPOSITORY_ID"), InstallationID: os.Getenv("SEEN_SOURCE_INSTALLATION_ID"), SourceRef: os.Getenv("SEEN_SOURCE_REF"), SourceCommit: os.Getenv("SEEN_SOURCE_COMMIT"), LicenseSPDX: os.Getenv("SEEN_SOURCE_LICENSE_SPDX")}
+	options := publishCLI{RegistryOrigin: envOr("SEEN_REGISTRY_ORIGIN", defaultPublishOrigin), TokenFile: os.Getenv("SEEN_REGISTRY_TOKEN_FILE"), SourceForge: envOr("SEEN_SOURCE_FORGE", defaultSourceForge), RepositoryID: os.Getenv("SEEN_SOURCE_REPOSITORY_ID"), InstallationID: os.Getenv("SEEN_SOURCE_INSTALLATION_ID"), SourceRef: os.Getenv("SEEN_SOURCE_REF"), SourceCommit: os.Getenv("SEEN_SOURCE_COMMIT"), LicenseSPDX: os.Getenv("SEEN_SOURCE_LICENSE_SPDX")}
 	for index := 0; index < len(arguments); index++ {
 		argument := arguments[index]
 		if argument == "--quiet" {
@@ -253,6 +255,8 @@ func parsePublishCLI(arguments []string) (publishCLI, error) {
 				options.RegistryOrigin = value
 			case "--token-file":
 				options.TokenFile = value
+			case "--source-forge":
+				options.SourceForge = value
 			case "--source-repository-id":
 				options.RepositoryID = value
 			case "--source-installation-id":
@@ -294,6 +298,9 @@ func (cli *publishCLI) fillManifestDefaults(document map[string]any) {
 }
 
 func (cli publishCLI) validateSource() error {
+	if cli.SourceForge != "github" && cli.SourceForge != "gitlab" {
+		return errors.New("source forge must be exactly github or gitlab")
+	}
 	missing := make([]string, 0, 5)
 	for _, field := range []struct {
 		name  string

--- a/tools/seen-pkg/internal/commands/publish_test.go
+++ b/tools/seen-pkg/internal/commands/publish_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/codeyousef/seen/tools/seen-pkg/internal/model"
 )
 
-func TestPublishUsesAuthenticatedContractFlowAndLeavesPublicReleaseDelayed(t *testing.T) {
+func TestPublishUsesAuthenticatedContractFlowAndLeavesPublicReleaseQuarantined(t *testing.T) {
 	project := t.TempDir()
 	manifestText := `manifest-version = 1
 
@@ -81,7 +81,7 @@ capabilities = []
 			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 				t.Error(err)
 			}
-			if body.Version != "0.1.0" || body.Visibility != "public" || body.Source.RepositoryID != "123456" {
+			if body.Version != "0.1.0" || body.Visibility != "public" || body.Source.Forge != "gitlab" || body.Source.RepositoryID != "123456" {
 				t.Errorf("unexpected reservation: %+v", body)
 			}
 			manifestDigest := sha256.Sum256([]byte(manifestText))
@@ -139,7 +139,7 @@ capabilities = []
 			}
 			response.Header().Set("Content-Type", "application/json")
 			response.WriteHeader(http.StatusAccepted)
-			if err := json.NewEncoder(response).Encode(validReleaseRecord("seen/registry-smoke", "0.1.0", "public", "delayed", "unavailable", reservedManifestSHA256, reservedDigest, reservedLength)); err != nil {
+			if err := json.NewEncoder(response).Encode(validReleaseRecord("seen/registry-smoke", "0.1.0", "public", "quarantined", "unavailable", reservedManifestSHA256, reservedDigest, reservedLength)); err != nil {
 				t.Error(err)
 			}
 		default:
@@ -158,6 +158,7 @@ capabilities = []
 	client := &http.Client{Transport: transport}
 
 	t.Setenv("SEEN_REGISTRY_TOKEN", token)
+	t.Setenv("SEEN_SOURCE_FORGE", "gitlab")
 	t.Setenv("SEEN_SOURCE_REPOSITORY_ID", "123456")
 	t.Setenv("SEEN_SOURCE_INSTALLATION_ID", "internal-dev-publisher")
 	t.Setenv("SEEN_SOURCE_REF", "refs/heads/feat/FEL-630-seen-registry-client")
@@ -171,7 +172,7 @@ capabilities = []
 	if code != 0 {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Submitted seen/registry-smoke@0.1.0") || strings.Contains(stdout.String(), "Published") || !strings.Contains(stdout.String(), "lifecycle=delayed") || !strings.Contains(stdout.String(), "72-hour delay") {
+	if !strings.Contains(stdout.String(), "Submitted seen/registry-smoke@0.1.0") || strings.Contains(stdout.String(), "Published") || !strings.Contains(stdout.String(), "lifecycle=quarantined") || !strings.Contains(stdout.String(), "72-hour delay") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
 	want := []string{
@@ -348,6 +349,7 @@ func TestPublishManifestMustRemainByteExactAfterPacking(t *testing.T) {
 
 func TestPublishSourceDeclarationEnforcesContractBoundsAndHTTPSRepository(t *testing.T) {
 	valid := publishCLI{
+		SourceForge:    "github",
 		RepositoryID:   "123456",
 		InstallationID: "internal-dev-publisher",
 		SourceRef:      "refs/heads/main",
@@ -362,6 +364,8 @@ func TestPublishSourceDeclarationEnforcesContractBoundsAndHTTPSRepository(t *tes
 		name   string
 		mutate func(*publishCLI)
 	}{
+		{"source-forge", func(cli *publishCLI) { cli.SourceForge = "bitbucket" }},
+		{"source-forge-case", func(cli *publishCLI) { cli.SourceForge = "GitHub" }},
 		{"repository-id", func(cli *publishCLI) { cli.RepositoryID = strings.Repeat("r", 129) }},
 		{"installation-id", func(cli *publishCLI) { cli.InstallationID = strings.Repeat("i", 129) }},
 		{"source-ref", func(cli *publishCLI) { cli.SourceRef = "refs/heads/" + strings.Repeat("r", 255) }},
@@ -378,6 +382,34 @@ func TestPublishSourceDeclarationEnforcesContractBoundsAndHTTPSRepository(t *tes
 				t.Fatal("invalid publish source declaration was accepted")
 			}
 		})
+	}
+}
+
+func TestParsePublishCLISourceForgeDefaultsAndOverrides(t *testing.T) {
+	t.Setenv("SEEN_SOURCE_FORGE", "")
+	defaults, err := parsePublishCLI(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaults.SourceForge != "github" {
+		t.Fatalf("default source forge = %q", defaults.SourceForge)
+	}
+
+	t.Setenv("SEEN_SOURCE_FORGE", "gitlab")
+	fromEnvironment, err := parsePublishCLI(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromEnvironment.SourceForge != "gitlab" {
+		t.Fatalf("environment source forge = %q", fromEnvironment.SourceForge)
+	}
+
+	fromFlag, err := parsePublishCLI([]string{"--source-forge", "github"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromFlag.SourceForge != "github" {
+		t.Fatalf("flag source forge = %q", fromFlag.SourceForge)
 	}
 }
 


### PR DESCRIPTION
## Summary

- define fail-closed source-proof and scan-attestation contracts
- expand adversarial archive and state-transition fixtures
- make publish source forge explicit and preserve quarantine after upload
- prepare immutable `seen/registry-smoke@0.1.1` for the development acceptance run

## Verification

- `python3 tests/package_registry_contracts.py`
- capped Go 1.26 container: `go test ./...`
- `git diff --check`

Linear: FEL-631