### PR TITLE
FEL-633: harden signed package metadata verification

### DIFF
--- a/contracts/package-registry/v1/README.md
+++ b/contracts/package-registry/v1/README.md
@@ -278,6 +278,15 @@ The owner/name, exact version, digest, and archive filename must match the targe
 custom fields, and the target hash must match the same digest. Clients and
 signers reject rather than decode, normalize, or repair any mismatch.
 
+Each target also carries a registry attestation binding the exact subject and
+blob length, publisher and registry-service identities, immutable source
+repository and commit, final scan result and policy/evidence versions, public
+visibility, and activation time. `registry_attestation_sha256` and the legacy
+`provenance_sha256` alias are both the SHA-256 of the canonical projection
+defined by the TUF schema; the source-proof digest must equal the review
+binding. Clients fail closed when any field is absent, inconsistent, or
+re-hashed under a different projection.
+
 Metadata signatures and metadata-file hashes use TUF canonical JSON, frozen as
 `tuf-canonical-json-v1` in the signing-policy schema and fixture. Ed25519 public
 keys are lowercase hex of 32 raw bytes, signatures are lowercase hex of 64 raw
@@ -296,6 +305,13 @@ production trust root and activates neither environment. The current package
 client separately distributes the official development root; production still
 fails closed without its own root. Planned key names or illustrative policy
 material never activate trust.
+
+The fixture's `client_conformance_cases` also freezes complete-chain behavior
+for a signed wrong-environment update, missing delegated metadata, an online
+key before and after offline delegation revocation, and recovery with its
+replacement key. Implementations must re-sign every changed role and rebuild
+snapshot/timestamp hash and length bindings before evaluating each case; an
+invalid signature is not a substitute for the expected policy decision.
 
 Bearer credentials for operations marked with a recent-auth maximum must carry
 the JWT NumericDate `auth_time` claim. The registry compares its server clock to

--- a/contracts/package-registry/v1/fixtures/tuf-metadata-examples.json
+++ b/contracts/package-registry/v1/fixtures/tuf-metadata-examples.json
@@ -11,106 +11,633 @@
   "trust_boundaries": {
     "test_repository_id": "seen-dev-test-fixture-v1",
     "test_registry_origin": "https://test.invalid/packages",
-    "development_official_root": {"status": "unconfigured", "client_behavior": "fail-closed"},
-    "production_official_root": {"status": "unconfigured", "client_behavior": "fail-closed"},
+    "development_official_root": {
+      "status": "unconfigured",
+      "client_behavior": "fail-closed"
+    },
+    "production_official_root": {
+      "status": "unconfigured",
+      "client_behavior": "fail-closed"
+    },
     "activation_rule": "an-official-root-is-trusted-only-when-its-complete-root-envelope-and-sha256-are-shipped-out-of-band-with-the-client"
   },
   "metadata_chain": {
-    "snapshot_meta_documents": {"targets.json": "targets", "releases.json": "release_targets", "security.json": "security_targets"},
-    "timestamp_meta_documents": {"snapshot.json": "snapshot"}
+    "snapshot_meta_documents": {
+      "targets.json": "targets",
+      "releases.json": "release_targets",
+      "security.json": "security_targets"
+    },
+    "timestamp_meta_documents": {
+      "snapshot.json": "snapshot"
+    }
   },
   "validation_time": "2030-01-01T00:00:00Z",
   "metadata": {
     "root": {
-      "signatures": [{"keyid": "a195875e924a21f18ad8c8a6e5231b2d9281cc8901489d0e8bfe310a9bd2da73", "sig": "e042c9160b6450bdb960048e6c75230f4a5351db4d2f0cc1560379a623097d6057b406c9fe000e11f27a736a6a0854cee7886bbbc6e6a77a941887823c56950e"}],
+      "signatures": [
+        {
+          "keyid": "f6d375d343214f3465842398959656e0d3539731f7448d32557e8b2eee5979cd",
+          "sig": "7b0879ba1e2545bc5277f13ccf604291380a76c16b8ff2b6260ae4d61257ba8f43538563dd522ca0bf1246c2d0a32ef5b6768ecd22a9ee84452f5689bb28d90b"
+        }
+      ],
       "signed": {
-        "_type": "root", "spec_version": "1.0", "version": 1, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1", "consistent_snapshot": true,
+        "_type": "root",
+        "spec_version": "1.0",
+        "version": 1,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
+        "consistent_snapshot": true,
         "keys": {
-          "a195875e924a21f18ad8c8a6e5231b2d9281cc8901489d0e8bfe310a9bd2da73": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bdaa46f4eeeadda9cc24e3d9e50a0eece62e8cb7fc1dc1e58ea99b1ced5c4854"}},
-          "1b61808c57664fc2b7c3c1e6b4ca1d9684e94bfca216bd187d85398979fd24bf": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "e776280f8517bbe64bc4b4a05170e33963ba5da1d72297322da57d1aa3317796"}},
-          "b1264212601b85d75b87ae7fd7e74d9739db71496d7ea3da8e55adfe565da25b": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "985980acc627de77b2a982a38a5894516f5a612145e3445ebf8c2f9be0d0c024"}},
-          "861a44232d99cde7f6d00ba04b8b56db262434749feb1e352f28a33bc8118794": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "e26d960ab76c5cdda6a2b4dc92313e180c8e1b2b826e55e49a143158701cd2a2"}},
-          "64b8fe5dd326074d0dd4db64a58d93a2cd91e573f947d19b24133af1d1b83b28": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "d6e140c18f8777624801b922ea94c454e592155be0f9b278b4f82699ac6d1e50"}},
-          "e5f8ea7cf2e7fb4c8eb2aa90388a029151ec5fefbe518f03e92c29c65f60507a": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "1b357cd9e1b5455bc27849f53da4a44d42d047d2950c96c841671794b68e6911"}}
+          "f6d375d343214f3465842398959656e0d3539731f7448d32557e8b2eee5979cd": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "bb942a5391175d26fb0afe9c717f2cf4f225d2ec734dd0dc626c87d2c6ac0d1e"
+            }
+          },
+          "f29b4705248a8c6489076e04593560e6e52044d2f95567fc0ea102c6ea4ccaad": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "867b98929c063e04607f23dff99103ac635ce5b7957fe28efadb22be44ef038d"
+            }
+          },
+          "d10245c81f57ba03ecc1d0031e21f1b61ae6830a083a4fff74c8855eaa736404": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "539752ab93a058a65cd8694e19f6d282c2da7460dac98afa9cd1c9b2ff883412"
+            }
+          },
+          "0aeac211a73cf556500f87465dd752bae7e40d0fdbc4f284d85f673527992b0b": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "9674d844dc72c0baebd8c5b8851d3e981972a6c9ec377da55f5473e5b784fe4e"
+            }
+          },
+          "c3ae79cb9af9a3566526fc210aedb2eb09ab91317e73e63751fb82b7c90577a5": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "4a341e65a07893ab953c2f027105233937e34eae418bcaf6839329d8fc02d9fd"
+            }
+          },
+          "e7f897935b684335367e18cde262b46b625fc090b4a886bd9e5c803aa04f4c96": {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "keyval": {
+              "public": "a0c6fb2f29172c356d33600228db006f724cb6e5e14f27a0436335b7fa90e875"
+            }
+          }
         },
         "roles": {
-          "root": {"keyids": ["a195875e924a21f18ad8c8a6e5231b2d9281cc8901489d0e8bfe310a9bd2da73"], "threshold": 1},
-          "targets": {"keyids": ["1b61808c57664fc2b7c3c1e6b4ca1d9684e94bfca216bd187d85398979fd24bf"], "threshold": 1},
-          "snapshot": {"keyids": ["64b8fe5dd326074d0dd4db64a58d93a2cd91e573f947d19b24133af1d1b83b28"], "threshold": 1},
-          "timestamp": {"keyids": ["e5f8ea7cf2e7fb4c8eb2aa90388a029151ec5fefbe518f03e92c29c65f60507a"], "threshold": 1}
+          "root": {
+            "keyids": [
+              "f6d375d343214f3465842398959656e0d3539731f7448d32557e8b2eee5979cd"
+            ],
+            "threshold": 1
+          },
+          "targets": {
+            "keyids": [
+              "f29b4705248a8c6489076e04593560e6e52044d2f95567fc0ea102c6ea4ccaad"
+            ],
+            "threshold": 1
+          },
+          "snapshot": {
+            "keyids": [
+              "c3ae79cb9af9a3566526fc210aedb2eb09ab91317e73e63751fb82b7c90577a5"
+            ],
+            "threshold": 1
+          },
+          "timestamp": {
+            "keyids": [
+              "e7f897935b684335367e18cde262b46b625fc090b4a886bd9e5c803aa04f4c96"
+            ],
+            "threshold": 1
+          }
         }
       }
     },
     "targets": {
-      "signatures": [{"keyid": "1b61808c57664fc2b7c3c1e6b4ca1d9684e94bfca216bd187d85398979fd24bf", "sig": "200508b9a96293253acec7fd75e1c9faa0f3bbdc870a77219d6ddd089642a90432090a4cfd8beb8a449fae75b1b8948f25777727b3889f543312c15abf2b4607"}],
+      "signatures": [
+        {
+          "keyid": "f29b4705248a8c6489076e04593560e6e52044d2f95567fc0ea102c6ea4ccaad",
+          "sig": "563dfa3b37fe3c9474cda7d4fa9c3c5aba4f715c92e5c71d3e9601879ef40a0b98b800ce776d58d5ba431b79182f669b9320d25196ef01944fadce1a5540480c"
+        }
+      ],
       "signed": {
-        "_type": "targets", "spec_version": "1.0", "version": 1, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1", "targets": {},
+        "_type": "targets",
+        "spec_version": "1.0",
+        "version": 1,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
+        "targets": {},
         "delegations": {
           "keys": {
-            "b1264212601b85d75b87ae7fd7e74d9739db71496d7ea3da8e55adfe565da25b": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "985980acc627de77b2a982a38a5894516f5a612145e3445ebf8c2f9be0d0c024"}},
-            "861a44232d99cde7f6d00ba04b8b56db262434749feb1e352f28a33bc8118794": {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "e26d960ab76c5cdda6a2b4dc92313e180c8e1b2b826e55e49a143158701cd2a2"}}
+            "d10245c81f57ba03ecc1d0031e21f1b61ae6830a083a4fff74c8855eaa736404": {
+              "keytype": "ed25519",
+              "scheme": "ed25519",
+              "keyval": {
+                "public": "539752ab93a058a65cd8694e19f6d282c2da7460dac98afa9cd1c9b2ff883412"
+              }
+            },
+            "0aeac211a73cf556500f87465dd752bae7e40d0fdbc4f284d85f673527992b0b": {
+              "keytype": "ed25519",
+              "scheme": "ed25519",
+              "keyval": {
+                "public": "9674d844dc72c0baebd8c5b8851d3e981972a6c9ec377da55f5473e5b784fe4e"
+              }
+            }
           },
           "roles": [
-            {"name": "security", "keyids": ["861a44232d99cde7f6d00ba04b8b56db262434749feb1e352f28a33bc8118794"], "threshold": 1, "terminating": false, "paths": ["packages/*/*/*/*/*"]},
-            {"name": "releases", "keyids": ["b1264212601b85d75b87ae7fd7e74d9739db71496d7ea3da8e55adfe565da25b"], "threshold": 1, "terminating": false, "paths": ["packages/*/*/*/*/*"]}
+            {
+              "name": "security",
+              "keyids": [
+                "0aeac211a73cf556500f87465dd752bae7e40d0fdbc4f284d85f673527992b0b"
+              ],
+              "threshold": 1,
+              "terminating": false,
+              "paths": [
+                "packages/*/*/*/*/*"
+              ]
+            },
+            {
+              "name": "releases",
+              "keyids": [
+                "d10245c81f57ba03ecc1d0031e21f1b61ae6830a083a4fff74c8855eaa736404"
+              ],
+              "threshold": 1,
+              "terminating": false,
+              "paths": [
+                "packages/*/*/*/*/*"
+              ]
+            }
           ]
         }
       }
     },
     "release_targets": {
-      "signatures": [{"keyid": "b1264212601b85d75b87ae7fd7e74d9739db71496d7ea3da8e55adfe565da25b", "sig": "6c11f235f697dd19e1561a56f5c47692a8a6216321399daf6ee0d15fb0d8d7cc027b8a2b622a9392187943371416f87b19b1f565ba91cb4158811eb9ca114803"}],
+      "signatures": [
+        {
+          "keyid": "d10245c81f57ba03ecc1d0031e21f1b61ae6830a083a4fff74c8855eaa736404",
+          "sig": "f38fd8fd2b35abf515e65a560906ff07bd80587aa4bd438667ed765b12f7771759ea9567866f8ef145657de7f77b102a270ba1d2a8e16988e26dc61e4ef65e09"
+        }
+      ],
       "signed": {
-        "_type": "targets", "spec_version": "1.0", "version": 2, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1",
+        "_type": "targets",
+        "spec_version": "1.0",
+        "version": 2,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
         "targets": {
           "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz": {
-            "length": 8192, "hashes": {"sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            "length": 8192,
+            "hashes": {
+              "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
             "custom": {
-              "environment": "development", "registry_origin": "https://test.invalid/packages", "package": "alice/mathx", "version": "1.2.3", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "archive_filename": "mathx-1.2.3.seenpkg.tgz", "visibility": "public", "lifecycle": "active", "retention": "retained", "availability": "available", "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "provenance_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "dependencies": [{"alias": "util", "package": "seen/util", "registry_origin": "https://test.invalid/packages", "requirement": "^1.0.0", "allow": []}], "capabilities": ["file"]
+              "environment": "development",
+              "registry_origin": "https://test.invalid/packages",
+              "package": "alice/mathx",
+              "owner": "alice",
+              "name": "mathx",
+              "version": "1.2.3",
+              "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+              "blob": {
+                "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "length": 8192
+              },
+              "publisher_principal": "publisher:alice",
+              "registry_service_identity": "release-promoter",
+              "source_repository": {
+                "forge": "github",
+                "repository_id": "987654321",
+                "canonical_url": "https://github.com/alice/mathx"
+              },
+              "source_commit": {
+                "algorithm": "sha1",
+                "value": "0123456789abcdef0123456789abcdef01234567"
+              },
+              "review": {
+                "result": "passed",
+                "policy_version": "package-scan-v1.0.0",
+                "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+                "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "scan_attestation_id": "scn_01JZX9M1N2P3Q4R5S6T7",
+                "scan_attestation_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                "scanner_id": "seen-package-scanner",
+                "scanner_version": "1.0.0",
+                "attestation_sequence": 4
+              },
+              "visibility": "public",
+              "lifecycle": "active",
+              "retention": "retained",
+              "availability": "available",
+              "activated_at": "2029-12-31T23:59:00Z",
+              "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "registry_attestation_sha256": "1ed1b79bb7df89e0bc9fdf10e19673824e5465c3a3eba02b57cc34f34bdfb465",
+              "provenance_sha256": "1ed1b79bb7df89e0bc9fdf10e19673824e5465c3a3eba02b57cc34f34bdfb465",
+              "dependencies": [
+                {
+                  "alias": "util",
+                  "package": "seen/util",
+                  "registry_origin": "https://test.invalid/packages",
+                  "requirement": "^1.0.0",
+                  "allow": []
+                }
+              ],
+              "capabilities": [
+                "file"
+              ]
             }
           }
         }
       }
     },
     "security_targets": {
-      "signatures": [{"keyid": "861a44232d99cde7f6d00ba04b8b56db262434749feb1e352f28a33bc8118794", "sig": "0a2f98c305dd01137237e1ccc9d1c756d3e3c79d4c5c6054a99309d4aa1872339503ca11cb8064a25f8af47ee9b4cb97e57cabcf09d6ccf46d36c8e687944905"}],
+      "signatures": [
+        {
+          "keyid": "0aeac211a73cf556500f87465dd752bae7e40d0fdbc4f284d85f673527992b0b",
+          "sig": "1f1a2bce8d46622bde752b689b252717e308841df67bef4f67edfd31fdc422a6e86ef5687d2d8d9e275233c43df08057fdbd16f6ee175db6860e53bbec235f06"
+        }
+      ],
       "signed": {
-        "_type": "targets", "spec_version": "1.0", "version": 3, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1",
+        "_type": "targets",
+        "spec_version": "1.0",
+        "version": 3,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
         "targets": {
           "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz": {
-            "length": 8192, "hashes": {"sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            "length": 8192,
+            "hashes": {
+              "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
             "custom": {
-              "environment": "development", "registry_origin": "https://test.invalid/packages", "package": "alice/mathx", "version": "1.2.3", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "archive_filename": "mathx-1.2.3.seenpkg.tgz", "visibility": "public", "lifecycle": "active", "retention": "retained", "availability": "security-quarantined", "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "provenance_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "dependencies": [{"alias": "util", "package": "seen/util", "registry_origin": "https://test.invalid/packages", "requirement": "^1.0.0", "allow": []}], "capabilities": ["file"], "incident_id": "inc_TEST_fixture_0001", "security_action": "quarantine"
+              "environment": "development",
+              "registry_origin": "https://test.invalid/packages",
+              "package": "alice/mathx",
+              "owner": "alice",
+              "name": "mathx",
+              "version": "1.2.3",
+              "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+              "blob": {
+                "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "length": 8192
+              },
+              "publisher_principal": "publisher:alice",
+              "registry_service_identity": "release-promoter",
+              "source_repository": {
+                "forge": "github",
+                "repository_id": "987654321",
+                "canonical_url": "https://github.com/alice/mathx"
+              },
+              "source_commit": {
+                "algorithm": "sha1",
+                "value": "0123456789abcdef0123456789abcdef01234567"
+              },
+              "review": {
+                "result": "passed",
+                "policy_version": "package-scan-v1.0.0",
+                "source_proof_id": "prf_01JZX8K9F7Q2W4N6M8R0",
+                "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "scan_attestation_id": "scn_01JZX9M1N2P3Q4R5S6T7",
+                "scan_attestation_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                "scanner_id": "seen-package-scanner",
+                "scanner_version": "1.0.0",
+                "attestation_sequence": 4
+              },
+              "visibility": "public",
+              "lifecycle": "active",
+              "retention": "retained",
+              "availability": "security-quarantined",
+              "activated_at": "2029-12-31T23:59:00Z",
+              "source_proof_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "registry_attestation_sha256": "1ed1b79bb7df89e0bc9fdf10e19673824e5465c3a3eba02b57cc34f34bdfb465",
+              "provenance_sha256": "1ed1b79bb7df89e0bc9fdf10e19673824e5465c3a3eba02b57cc34f34bdfb465",
+              "dependencies": [
+                {
+                  "alias": "util",
+                  "package": "seen/util",
+                  "registry_origin": "https://test.invalid/packages",
+                  "requirement": "^1.0.0",
+                  "allow": []
+                }
+              ],
+              "capabilities": [
+                "file"
+              ],
+              "incident_id": "inc_TEST_fixture_0001",
+              "security_action": "quarantine"
             }
           }
         }
       }
     },
     "snapshot": {
-      "signatures": [{"keyid": "64b8fe5dd326074d0dd4db64a58d93a2cd91e573f947d19b24133af1d1b83b28", "sig": "dfba990383b1541fd44bb9c7b8fc028224880b5ab1f70c0ce14bd4793cf9003001d32d584afde7a097a30a5ec0ef6b542ced2c436af7ba9d7982aa1cafb67903"}],
+      "signatures": [
+        {
+          "keyid": "c3ae79cb9af9a3566526fc210aedb2eb09ab91317e73e63751fb82b7c90577a5",
+          "sig": "0ffcb1ce0fda486187bca373a88fd6420823f6c4c99657095414ebba3a15f3a3a870f17e5169b8ef7728dcdb2472910eaf88889dae8f510be302de08d505ed07"
+        }
+      ],
       "signed": {
-        "_type": "snapshot", "spec_version": "1.0", "version": 4, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1",
+        "_type": "snapshot",
+        "spec_version": "1.0",
+        "version": 4,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
         "meta": {
-          "targets.json": {"version": 1, "length": 1160, "hashes": {"sha256": "06867f907f607e406e7756c931be196e4cf377cf8aeedd5b68b9b1e627526b5f"}},
-          "releases.json": {"version": 2, "length": 1322, "hashes": {"sha256": "396673615ed904c1027894333916c17255d202b3ab6fef8cda4d988631d9522f"}},
-          "security.json": {"version": 3, "length": 1402, "hashes": {"sha256": "496d0530188d40c7a896d69688923afe719a068404716a5fb451ba58c98bccf0"}}
+          "targets.json": {
+            "version": 1,
+            "length": 1160,
+            "hashes": {
+              "sha256": "6e7f71cd6d913f78e80757246ac26d16af86eea25127a5280895c1e5f4c100a3"
+            }
+          },
+          "releases.json": {
+            "version": 2,
+            "length": 2309,
+            "hashes": {
+              "sha256": "4c149ab45c752ba3cd11843969b8544f1f331ea27b89ed23e385bf6a2dc50361"
+            }
+          },
+          "security.json": {
+            "version": 3,
+            "length": 2389,
+            "hashes": {
+              "sha256": "19e3b9256422c40c49a6a1645ef92423359e2a6a0d91295d1faf701497d8ea63"
+            }
+          }
         }
       }
     },
     "timestamp": {
-      "signatures": [{"keyid": "e5f8ea7cf2e7fb4c8eb2aa90388a029151ec5fefbe518f03e92c29c65f60507a", "sig": "ea8f05b6697573a33dc3d34318c43f1be2bddae7a4e7f8de33ac4c40b2d26b1d5b0f56b1f5204474751ad95214622795c07c8384977f03f7f6be4fe64e0e7000"}],
+      "signatures": [
+        {
+          "keyid": "e7f897935b684335367e18cde262b46b625fc090b4a886bd9e5c803aa04f4c96",
+          "sig": "a885cd18bbf18c6e4efcb9df38e2d0802ce6c9ee9156e202972c5e8899d2fe13a2e317a6c0c1d1515d4ab41f85eff7c73729e9427d138daadfae75857bd47d04"
+        }
+      ],
       "signed": {
-        "_type": "timestamp", "spec_version": "1.0", "version": 5, "expires": "2035-01-01T00:00:00Z", "environment": "development", "repository_id": "seen-dev-test-fixture-v1",
-        "meta": {"snapshot.json": {"version": 4, "length": 798, "hashes": {"sha256": "06dd7d6e67dae4801a5a20659b57f8e4c36c6be8f7d3d7d2c3670fdf8f224384"}}}
+        "_type": "timestamp",
+        "spec_version": "1.0",
+        "version": 5,
+        "expires": "2035-01-01T00:00:00Z",
+        "environment": "development",
+        "repository_id": "seen-dev-test-fixture-v1",
+        "meta": {
+          "snapshot.json": {
+            "version": 4,
+            "length": 798,
+            "hashes": {
+              "sha256": "8d53ede3ae5cfb3aabbea0f97012ce9dbd5f54a7b3f0690abf4b053be87d9880"
+            }
+          }
+        }
       }
     }
   },
+  "client_conformance_cases": [
+    {
+      "name": "wrong-environment-signed-chain",
+      "initial_state": "trusted-root-only",
+      "steps": [
+        {
+          "action": "refresh-complete-chain-resigned-with-release-environment-changed",
+          "expected": "reject",
+          "error_code": "signing_environment_mismatch"
+        }
+      ]
+    },
+    {
+      "name": "missing-delegated-metadata",
+      "initial_state": "trusted-root-only",
+      "steps": [
+        {
+          "action": "refresh-complete-chain-with-security-metadata-absent",
+          "expected": "reject",
+          "error_code": "signing_metadata_invalid"
+        }
+      ]
+    },
+    {
+      "name": "compromised-online-key-remains-authorized-before-revocation",
+      "initial_state": "base-metadata-refreshed",
+      "steps": [
+        {
+          "action": "refresh-next-release-version-signed-by-current-delegated-key",
+          "expected": "accept"
+        }
+      ]
+    },
+    {
+      "name": "revoked-delegation-rejects-former-online-key",
+      "initial_state": "base-metadata-refreshed",
+      "steps": [
+        {
+          "action": "refresh-resigned-chain-after-offline-targets-replaces-release-key-but-release-uses-former-key",
+          "expected": "reject",
+          "error_code": "signing_unknown_key"
+        }
+      ]
+    },
+    {
+      "name": "replacement-delegation-recovers-after-compromise",
+      "initial_state": "base-metadata-refreshed",
+      "steps": [
+        {
+          "action": "reject-resigned-chain-after-offline-targets-replaces-release-key-but-release-uses-former-key",
+          "expected": "reject",
+          "error_code": "signing_unknown_key"
+        },
+        {
+          "action": "refresh-same-next-versions-resigned-by-replacement-release-key",
+          "expected": "accept"
+        }
+      ]
+    }
+  ],
   "target_binding_cases": [
-    {"name": "canonical-public-release-target", "role": "releases", "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz", "custom": {"package": "alice/mathx", "version": "1.2.3", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "archive_filename": "mathx-1.2.3.seenpkg.tgz", "visibility": "public", "lifecycle": "active", "retention": "retained", "availability": "available"}, "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "expected": "accept"},
-    {"name": "path-package-does-not-match-custom", "role": "releases", "target_path": "packages/mallory/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz", "custom": {"package": "alice/mathx", "version": "1.2.3", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "archive_filename": "mathx-1.2.3.seenpkg.tgz", "visibility": "public", "lifecycle": "active", "retention": "retained", "availability": "available"}, "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "expected": "reject", "error_code": "signing_target_path_identity_mismatch"},
-    {"name": "security-role-quarantine-is-authoritative", "role": "security", "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz", "custom": {"package": "alice/mathx", "version": "1.2.3", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "archive_filename": "mathx-1.2.3.seenpkg.tgz", "visibility": "public", "lifecycle": "active", "retention": "retained", "availability": "security-quarantined", "incident_id": "inc_TEST_fixture_0001", "security_action": "quarantine"}, "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "expected": "accept"}
+    {
+      "name": "canonical-public-release-target",
+      "role": "releases",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "custom": {
+        "package": "alice/mathx",
+        "owner": "alice",
+        "name": "mathx",
+        "version": "1.2.3",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+        "blob": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "length": 8192
+        },
+        "visibility": "public",
+        "lifecycle": "active",
+        "retention": "retained",
+        "availability": "available"
+      },
+      "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_length": 8192,
+      "expected": "accept"
+    },
+    {
+      "name": "path-package-does-not-match-custom",
+      "role": "releases",
+      "target_path": "packages/mallory/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "custom": {
+        "package": "alice/mathx",
+        "owner": "alice",
+        "name": "mathx",
+        "version": "1.2.3",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+        "blob": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "length": 8192
+        },
+        "visibility": "public",
+        "lifecycle": "active",
+        "retention": "retained",
+        "availability": "available"
+      },
+      "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_length": 8192,
+      "expected": "reject",
+      "error_code": "signing_target_path_identity_mismatch"
+    },
+    {
+      "name": "attested-owner-does-not-match-target-path",
+      "role": "releases",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "custom": {
+        "package": "alice/mathx",
+        "owner": "mallory",
+        "name": "mathx",
+        "version": "1.2.3",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+        "blob": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "length": 8192
+        },
+        "visibility": "public",
+        "lifecycle": "active",
+        "retention": "retained",
+        "availability": "available"
+      },
+      "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_length": 8192,
+      "expected": "reject",
+      "error_code": "signing_target_path_identity_mismatch"
+    },
+    {
+      "name": "attested-blob-does-not-match-target-length",
+      "role": "releases",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "custom": {
+        "package": "alice/mathx",
+        "owner": "alice",
+        "name": "mathx",
+        "version": "1.2.3",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+        "blob": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "length": 8191
+        },
+        "visibility": "public",
+        "lifecycle": "active",
+        "retention": "retained",
+        "availability": "available"
+      },
+      "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_length": 8192,
+      "expected": "reject",
+      "error_code": "signing_target_attestation_invalid"
+    },
+    {
+      "name": "security-role-quarantine-is-authoritative",
+      "role": "security",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "custom": {
+        "package": "alice/mathx",
+        "owner": "alice",
+        "name": "mathx",
+        "version": "1.2.3",
+        "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archive_filename": "mathx-1.2.3.seenpkg.tgz",
+        "blob": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "length": 8192
+        },
+        "visibility": "public",
+        "lifecycle": "active",
+        "retention": "retained",
+        "availability": "security-quarantined",
+        "incident_id": "inc_TEST_fixture_0001",
+        "security_action": "quarantine"
+      },
+      "target_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_length": 8192,
+      "expected": "accept"
+    }
   ],
   "overlay_resolution_cases": [
-    {"name": "security-quarantine-overrides-release-availability", "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz", "candidates": [{"role": "security", "present": true, "availability": "security-quarantined", "incident_id": "inc_TEST_fixture_0001", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, {"role": "releases", "present": true, "availability": "available", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}], "expected": {"decision": "select", "role": "security", "availability": "security-quarantined"}},
-    {"name": "missing-security-overlay-falls-through", "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz", "candidates": [{"role": "security", "present": false}, {"role": "releases", "present": true, "availability": "available", "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}], "expected": {"decision": "select", "role": "releases", "availability": "available"}}
+    {
+      "name": "security-quarantine-overrides-release-availability",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "candidates": [
+        {
+          "role": "security",
+          "present": true,
+          "availability": "security-quarantined",
+          "incident_id": "inc_TEST_fixture_0001",
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "role": "releases",
+          "present": true,
+          "availability": "available",
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "expected": {
+        "decision": "select",
+        "role": "security",
+        "availability": "security-quarantined"
+      }
+    },
+    {
+      "name": "missing-security-overlay-falls-through",
+      "target_path": "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz",
+      "candidates": [
+        {
+          "role": "security",
+          "present": false
+        },
+        {
+          "role": "releases",
+          "present": true,
+          "availability": "available",
+          "archive_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "expected": {
+        "decision": "select",
+        "role": "releases",
+        "availability": "available"
+      }
+    }
   ]
 }

--- a/contracts/package-registry/v1/schemas/tuf-metadata-envelope-v1.schema.json
+++ b/contracts/package-registry/v1/schemas/tuf-metadata-envelope-v1.schema.json
@@ -12,13 +12,27 @@
       "comparison": "byte-exact-without-decoding-or-normalization",
       "requires": [
         "custom.package-equals-owner-slash-name",
+        "custom.owner-and-name-equal-target-path",
         "custom.version-equals-version",
         "custom.archive_sha256-equals-archive_sha256",
         "custom.archive_filename-equals-archive_filename",
         "custom.archive_filename-equals-name-dash-version-dot-seenpkg-dot-tgz",
-        "hashes.sha256-equals-custom.archive_sha256"
+        "hashes.sha256-equals-custom.archive_sha256",
+        "custom.blob-equals-target-length-and-hash"
       ],
       "failure": "reject-before-signing-or-client-selection"
+    },
+    "registry_attestation_binding": {
+      "canonical_projection": {
+        "subject": ["package", "owner", "name", "version", "blob", "visibility"],
+        "publisher": ["publisher_principal", "registry_service_identity"],
+        "source": ["source_repository", "source_commit"],
+        "review": "review",
+        "activation": "activated_at"
+      },
+      "digest": "custom.registry_attestation_sha256-and-custom.provenance_sha256-equal-sha256-of-tuf-canonical-json-projection",
+      "source_proof": "custom.source_proof_sha256-equals-custom.review.source_proof_sha256",
+      "failure": "reject-before-client-selection"
     },
     "release_role_eligibility": {
       "state": {
@@ -128,14 +142,24 @@
             "environment",
             "registry_origin",
             "package",
+            "owner",
+            "name",
             "version",
             "archive_sha256",
             "archive_filename",
+            "blob",
+            "publisher_principal",
+            "registry_service_identity",
+            "source_repository",
+            "source_commit",
+            "review",
             "visibility",
             "lifecycle",
             "retention",
             "availability",
+            "activated_at",
             "source_proof_sha256",
+            "registry_attestation_sha256",
             "provenance_sha256",
             "dependencies",
             "capabilities"
@@ -150,6 +174,8 @@
               "type": "string",
               "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
             },
+            "owner": {"$ref": "#/$defs/packageComponent"},
+            "name": {"$ref": "#/$defs/packageComponent"},
             "version": {"$ref": "#/$defs/exactVersion"},
             "archive_sha256": {"$ref": "#/$defs/sha256"},
             "archive_filename": {
@@ -158,11 +184,29 @@
               "maxLength": 256,
               "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?-[0-9A-Za-z.+-]{5,128}\\.seenpkg\\.tgz$"
             },
+            "blob": {"$ref": "#/$defs/attestedBlob"},
+            "publisher_principal": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9:@._/-]*$"
+            },
+            "registry_service_identity": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$"
+            },
+            "source_repository": {"$ref": "#/$defs/attestedRepository"},
+            "source_commit": {"$ref": "#/$defs/attestedCommit"},
+            "review": {"$ref": "#/$defs/attestedReview"},
             "visibility": {"const": "public"},
             "lifecycle": {"const": "active"},
             "retention": {"const": "retained"},
             "availability": {"enum": ["available", "yanked", "security-quarantined"]},
+            "activated_at": {"type": "string", "format": "date-time"},
             "source_proof_sha256": {"$ref": "#/$defs/sha256"},
+            "registry_attestation_sha256": {"$ref": "#/$defs/sha256"},
             "provenance_sha256": {"$ref": "#/$defs/sha256"},
             "dependencies": {
               "type": "array",
@@ -212,6 +256,82 @@
             }
           ]
         }
+      }
+    },
+    "packageComponent": {
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+    },
+    "attestedBlob": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "length"],
+      "properties": {
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "length": {"type": "integer", "minimum": 1, "maximum": 26214400}
+      }
+    },
+    "attestedRepository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forge", "repository_id", "canonical_url"],
+      "properties": {
+        "forge": {"enum": ["github", "gitlab"]},
+        "repository_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+        },
+        "canonical_url": {
+          "type": "string",
+          "pattern": "^https://[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?:/[A-Za-z0-9._~-]+)+$"
+        }
+      }
+    },
+    "attestedCommit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {"enum": ["sha1", "sha256"]},
+        "value": {"type": "string", "pattern": "^[0-9a-f]{40}(?:[0-9a-f]{24})?$"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"algorithm": {"const": "sha1"}}, "required": ["algorithm"]},
+          "then": {"properties": {"value": {"pattern": "^[0-9a-f]{40}$"}}}
+        },
+        {
+          "if": {"properties": {"algorithm": {"const": "sha256"}}, "required": ["algorithm"]},
+          "then": {"properties": {"value": {"pattern": "^[0-9a-f]{64}$"}}}
+        }
+      ]
+    },
+    "attestedReview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result",
+        "policy_version",
+        "source_proof_id",
+        "source_proof_sha256",
+        "scan_attestation_id",
+        "scan_attestation_sha256",
+        "scanner_id",
+        "scanner_version",
+        "attestation_sequence"
+      ],
+      "properties": {
+        "result": {"const": "passed"},
+        "policy_version": {"type": "string", "minLength": 1, "maxLength": 128},
+        "source_proof_id": {"type": "string", "pattern": "^prf_[A-Za-z0-9_-]{8,96}$"},
+        "source_proof_sha256": {"$ref": "#/$defs/sha256"},
+        "scan_attestation_id": {"type": "string", "pattern": "^scn_[A-Za-z0-9_-]{8,96}$"},
+        "scan_attestation_sha256": {"$ref": "#/$defs/sha256"},
+        "scanner_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "scanner_version": {"type": "string", "minLength": 1, "maxLength": 128},
+        "attestation_sequence": {"type": "integer", "minimum": 1}
       }
     },
     "capability": {

--- a/tests/package_registry_contracts.py
+++ b/tests/package_registry_contracts.py
@@ -1668,6 +1668,7 @@ def target_binding_error(
     role_name: str,
     target_path: str,
     target_sha256: str,
+    target_length: int,
     custom: dict[str, Any],
 ) -> str | None:
     pieces = target_path.split("/")
@@ -1675,6 +1676,8 @@ def target_binding_error(
         return "signing_path_not_delegated"
     _, owner, name, path_version, path_digest, path_leaf = pieces
     if f"{owner}/{name}" != custom["package"]:
+        return "signing_target_path_identity_mismatch"
+    if owner != custom["owner"] or name != custom["name"]:
         return "signing_target_path_identity_mismatch"
     if path_version != custom["version"]:
         return "signing_target_path_version_mismatch"
@@ -1684,6 +1687,8 @@ def target_binding_error(
         return "signing_target_path_leaf_mismatch"
     if target_sha256 != custom["archive_sha256"]:
         return "signing_target_hash_mismatch"
+    if custom["blob"] != {"sha256": target_sha256, "length": target_length}:
+        return "signing_target_attestation_invalid"
 
     if role_name == "releases":
         if custom["visibility"] != "public":
@@ -1986,6 +1991,51 @@ def check_signing_contracts() -> None:
     assert trust["development_official_root"]["client_behavior"] == "fail-closed"
     assert trust["production_official_root"]["client_behavior"] == "fail-closed"
 
+    conformance_cases = {
+        case["name"]: case for case in tuf_fixture["client_conformance_cases"]
+    }
+    assert len(conformance_cases) == len(tuf_fixture["client_conformance_cases"])
+    assert set(conformance_cases) == {
+        "wrong-environment-signed-chain",
+        "missing-delegated-metadata",
+        "compromised-online-key-remains-authorized-before-revocation",
+        "revoked-delegation-rejects-former-online-key",
+        "replacement-delegation-recovers-after-compromise",
+    }
+    expected_conformance_results = {
+        "wrong-environment-signed-chain": [
+            ("reject", "signing_environment_mismatch")
+        ],
+        "missing-delegated-metadata": [
+            ("reject", "signing_metadata_invalid")
+        ],
+        "compromised-online-key-remains-authorized-before-revocation": [
+            ("accept", None)
+        ],
+        "revoked-delegation-rejects-former-online-key": [
+            ("reject", "signing_unknown_key")
+        ],
+        "replacement-delegation-recovers-after-compromise": [
+            ("reject", "signing_unknown_key"),
+            ("accept", None),
+        ],
+    }
+    for name, case in conformance_cases.items():
+        assert case["initial_state"] in {
+            "trusted-root-only",
+            "base-metadata-refreshed",
+        }
+        assert case["steps"]
+        observed = [
+            (step["expected"], step.get("error_code"))
+            for step in case["steps"]
+        ]
+        assert observed == expected_conformance_results[name], name
+        for step in case["steps"]:
+            assert step["action"]
+            assert step["expected"] in {"accept", "reject"}
+            assert ("error_code" in step) == (step["expected"] == "reject")
+
     root_signed = metadata["root"]["signed"]
     root_keys = root_signed["keys"]
     delegated = metadata["targets"]["signed"]["delegations"]
@@ -2032,16 +2082,46 @@ def check_signing_contracts() -> None:
             canonical_json_bytes(signed),
         )
         for target_path, target in signed.get("targets", {}).items():
-            assert target["hashes"]["sha256"] == target["custom"]["archive_sha256"]
-            assert target["custom"]["environment"] == "development"
-            assert target["custom"]["registry_origin"] == trust["test_registry_origin"]
-            assert isinstance(target["custom"]["dependencies"], list)
-            assert isinstance(target["custom"]["capabilities"], list)
+            custom = target["custom"]
+            assert target["hashes"]["sha256"] == custom["archive_sha256"]
+            assert custom["blob"] == {
+                "sha256": target["hashes"]["sha256"],
+                "length": target["length"],
+            }
+            assert custom["package"] == f'{custom["owner"]}/{custom["name"]}'
+            assert custom["environment"] == "development"
+            assert custom["registry_origin"] == trust["test_registry_origin"]
+            assert custom["review"]["result"] == "passed"
+            assert custom["source_proof_sha256"] == custom["review"]["source_proof_sha256"]
+            attestation_projection = {
+                "subject": {
+                    "package": custom["package"],
+                    "owner": custom["owner"],
+                    "name": custom["name"],
+                    "version": custom["version"],
+                    "blob": custom["blob"],
+                    "visibility": custom["visibility"],
+                },
+                "publisher_principal": custom["publisher_principal"],
+                "registry_service_identity": custom["registry_service_identity"],
+                "source_repository": custom["source_repository"],
+                "source_commit": custom["source_commit"],
+                "review": custom["review"],
+                "activated_at": custom["activated_at"],
+            }
+            attestation_sha256 = hashlib.sha256(
+                canonical_json_bytes(attestation_projection)
+            ).hexdigest()
+            assert custom["registry_attestation_sha256"] == attestation_sha256
+            assert custom["provenance_sha256"] == attestation_sha256
+            assert isinstance(custom["dependencies"], list)
+            assert isinstance(custom["capabilities"], list)
             if document_name == "release_targets":
                 assert target_binding_error(
                     "releases",
                     target_path,
                     target["hashes"]["sha256"],
+                    target["length"],
                     target["custom"],
                 ) is None
             if document_name == "security_targets":
@@ -2049,6 +2129,7 @@ def check_signing_contracts() -> None:
                     "security",
                     target_path,
                     target["hashes"]["sha256"],
+                    target["length"],
                     target["custom"],
                 ) is None
 
@@ -2079,6 +2160,7 @@ def check_signing_contracts() -> None:
             case["role"],
             case["target_path"],
             case["target_sha256"],
+            case["target_length"],
             case["custom"],
         )
         assert observed == case.get("error_code"), case["name"]

--- a/tools/seen-pkg/internal/commands/registry.go
+++ b/tools/seen-pkg/internal/commands/registry.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/codeyousef/seen/tools/seen-pkg/internal/atomicfile"
 	"github.com/codeyousef/seen/tools/seen-pkg/internal/model"
@@ -50,6 +51,7 @@ type registryRuntime struct {
 	preferCached bool
 	verified     map[string]*tuf.Repository
 	policy       transport.Policy
+	now          func() time.Time
 }
 
 func newRegistryRuntime(specs []registrySpec, cacheRoot string, offline bool) *registryRuntime {
@@ -57,7 +59,7 @@ func newRegistryRuntime(specs []registrySpec, cacheRoot string, offline bool) *r
 	for _, spec := range specs {
 		byOrigin[spec.Origin] = spec
 	}
-	return &registryRuntime{specs: byOrigin, metadataRoot: filepath.Join(cacheRoot, "metadata"), offline: offline, verified: map[string]*tuf.Repository{}, policy: transport.DefaultPolicy()}
+	return &registryRuntime{specs: byOrigin, metadataRoot: filepath.Join(cacheRoot, "metadata"), offline: offline, verified: map[string]*tuf.Repository{}, policy: transport.DefaultPolicy(), now: time.Now}
 }
 
 func (runtime *registryRuntime) Candidates(ctx context.Context, key model.PackageKey, access resolver.Access) ([]model.Candidate, error) {
@@ -151,7 +153,7 @@ func (runtime *registryRuntime) load(ctx context.Context, origin string, offline
 	if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
 		return nil, loadErr
 	}
-	verifier, err := tuf.New(tuf.Config{Environment: spec.Environment, RepositoryID: spec.RepositoryID, RegistryOrigin: spec.Origin, Store: transaction})
+	verifier, err := tuf.New(tuf.Config{Environment: spec.Environment, RepositoryID: spec.RepositoryID, RegistryOrigin: spec.Origin, Store: transaction, Now: runtime.now})
 	if err != nil {
 		return nil, err
 	}

--- a/tools/seen-pkg/internal/commands/registry_test.go
+++ b/tools/seen-pkg/internal/commands/registry_test.go
@@ -272,6 +272,7 @@ func TestCustomRegistryAutomaticFetchReusesTrustedIdentity(t *testing.T) {
 		t.Fatalf("derived identity = %+v", automaticSpecs[0])
 	}
 	runtime := newRegistryRuntime(automaticSpecs, cacheRoot, true)
+	runtime.now = func() time.Time { return now }
 	candidates, err := runtime.Candidates(context.Background(), model.PackageKey{RegistryOrigin: origin, Package: "alice/mathx"}, resolver.Access{Offline: true})
 	if err != nil || len(candidates) != 1 {
 		t.Fatalf("automatic cached fetch candidates = %+v, %v", candidates, err)

--- a/tools/seen-pkg/internal/tuf/types.go
+++ b/tools/seen-pkg/internal/tuf/types.go
@@ -47,24 +47,62 @@ type FileMeta struct {
 	Hashes  map[string]string `json:"hashes"`
 }
 
+type AttestedBlob struct {
+	SHA256 string `json:"sha256"`
+	Length int64  `json:"length"`
+}
+
+type AttestedRepository struct {
+	Forge        string `json:"forge"`
+	RepositoryID string `json:"repository_id"`
+	CanonicalURL string `json:"canonical_url"`
+}
+
+type AttestedCommit struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
+}
+
+type AttestedReview struct {
+	Result                string `json:"result"`
+	PolicyVersion         string `json:"policy_version"`
+	SourceProofID         string `json:"source_proof_id"`
+	SourceProofSHA256     string `json:"source_proof_sha256"`
+	ScanAttestationID     string `json:"scan_attestation_id"`
+	ScanAttestationSHA256 string `json:"scan_attestation_sha256"`
+	ScannerID             string `json:"scanner_id"`
+	ScannerVersion        string `json:"scanner_version"`
+	AttestationSequence   int64  `json:"attestation_sequence"`
+}
+
 type TargetCustom struct {
-	Environment       string             `json:"environment"`
-	RegistryOrigin    string             `json:"registry_origin"`
-	Package           string             `json:"package"`
-	Version           string             `json:"version"`
-	ArchiveSHA256     string             `json:"archive_sha256"`
-	ArchiveFilename   string             `json:"archive_filename"`
-	Visibility        string             `json:"visibility"`
-	Lifecycle         string             `json:"lifecycle"`
-	Retention         string             `json:"retention"`
-	Availability      string             `json:"availability"`
-	SourceProofSHA256 string             `json:"source_proof_sha256"`
-	ProvenanceSHA256  string             `json:"provenance_sha256"`
-	Dependencies      []TargetDependency `json:"dependencies"`
-	Capabilities      []string           `json:"capabilities"`
-	YankReason        string             `json:"yank_reason,omitempty"`
-	IncidentID        string             `json:"incident_id,omitempty"`
-	SecurityAction    string             `json:"security_action,omitempty"`
+	Environment               string             `json:"environment"`
+	RegistryOrigin            string             `json:"registry_origin"`
+	Package                   string             `json:"package"`
+	Owner                     string             `json:"owner"`
+	Name                      string             `json:"name"`
+	Version                   string             `json:"version"`
+	ArchiveSHA256             string             `json:"archive_sha256"`
+	ArchiveFilename           string             `json:"archive_filename"`
+	Blob                      AttestedBlob       `json:"blob"`
+	PublisherPrincipal        string             `json:"publisher_principal"`
+	RegistryServiceIdentity   string             `json:"registry_service_identity"`
+	SourceRepository          AttestedRepository `json:"source_repository"`
+	SourceCommit              AttestedCommit     `json:"source_commit"`
+	Review                    AttestedReview     `json:"review"`
+	Visibility                string             `json:"visibility"`
+	Lifecycle                 string             `json:"lifecycle"`
+	Retention                 string             `json:"retention"`
+	Availability              string             `json:"availability"`
+	ActivatedAt               string             `json:"activated_at"`
+	SourceProofSHA256         string             `json:"source_proof_sha256"`
+	RegistryAttestationSHA256 string             `json:"registry_attestation_sha256"`
+	ProvenanceSHA256          string             `json:"provenance_sha256"`
+	Dependencies              []TargetDependency `json:"dependencies"`
+	Capabilities              []string           `json:"capabilities"`
+	YankReason                string             `json:"yank_reason,omitempty"`
+	IncidentID                string             `json:"incident_id,omitempty"`
+	SecurityAction            string             `json:"security_action,omitempty"`
 }
 
 // TargetDependency is the signed transitive graph input. Alias belongs to the

--- a/tools/seen-pkg/internal/tuf/verify.go
+++ b/tools/seen-pkg/internal/tuf/verify.go
@@ -25,9 +25,16 @@ var (
 	componentPattern  = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
 	semverPattern     = regexp.MustCompile(`^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 	incidentPattern   = regexp.MustCompile(`^inc_[A-Za-z0-9_-]{8,96}$`)
+	proofIDPattern    = regexp.MustCompile(`^prf_[A-Za-z0-9_-]{8,96}$`)
+	scanIDPattern     = regexp.MustCompile(`^scn_[A-Za-z0-9_-]{8,96}$`)
 	repositoryPattern = regexp.MustCompile(`^seen-(dev|prod)-[a-z0-9-]+$`)
 	aliasPattern      = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 	originPathPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._~-]*$`)
+	principalPattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9:@._/-]{0,255}$`)
+	servicePattern    = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$`)
+	sourceIDPattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
+	sourceURLPattern  = regexp.MustCompile(`^https://[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?:/[A-Za-z0-9._~-]+)+$`)
+	commitPattern     = regexp.MustCompile(`^[0-9a-f]+$`)
 )
 
 var capabilities = map[string]bool{
@@ -585,6 +592,9 @@ func (v *Verifier) validateTarget(role, targetPath string, target TargetMeta) er
 	if custom.Package != owner+"/"+name {
 		return failure("signing_target_path_identity_mismatch", errors.New("path and custom package differ"))
 	}
+	if custom.Owner != owner || custom.Name != name {
+		return failure("signing_target_path_identity_mismatch", errors.New("path and attested owner/name differ"))
+	}
 	if custom.Version != version {
 		return failure("signing_target_path_version_mismatch", errors.New("path and custom version differ"))
 	}
@@ -597,6 +607,9 @@ func (v *Verifier) validateTarget(role, targetPath string, target TargetMeta) er
 	}
 	if target.Length < 1 || target.Length > 25*1024*1024 || len(target.Hashes) != 1 || target.Hashes["sha256"] != archiveDigest {
 		return failure("signing_target_hash_mismatch", errors.New("target length or digest binding is invalid"))
+	}
+	if custom.Blob.SHA256 != archiveDigest || custom.Blob.Length != target.Length {
+		return failure("signing_target_attestation_invalid", errors.New("attested blob does not match target bytes"))
 	}
 	if custom.Environment != v.config.Environment {
 		return failure("signing_environment_mismatch", errors.New("target environment mismatch"))
@@ -613,8 +626,8 @@ func (v *Verifier) validateTarget(role, targetPath string, target TargetMeta) er
 	if custom.Retention != "retained" {
 		return failure("signing_release_not_retained", errors.New("public metadata contains nonretained release"))
 	}
-	if !validDigest(custom.SourceProofSHA256) || !validDigest(custom.ProvenanceSHA256) {
-		return failure("signing_target_attestation_invalid", errors.New("source proof and provenance digests are required"))
+	if err := v.validateRegistryAttestation(custom); err != nil {
+		return err
 	}
 	if custom.Dependencies == nil || custom.Capabilities == nil {
 		return failure("signing_target_graph_invalid", errors.New("signed dependencies and capabilities arrays are required"))
@@ -640,6 +653,9 @@ func (v *Verifier) validateTarget(role, targetPath string, target TargetMeta) er
 			return failure("signing_wrong_role", errors.New("release role contains security action"))
 		}
 	case "security":
+		if custom.YankReason != "" {
+			return failure("signing_metadata_invalid", errors.New("security target has yank reason"))
+		}
 		if !incidentPattern.MatchString(custom.IncidentID) {
 			return failure("signing_security_incident_required", errors.New("security target lacks incident ID"))
 		}
@@ -652,6 +668,106 @@ func (v *Verifier) validateTarget(role, targetPath string, target TargetMeta) er
 		return failure("signing_wrong_role", errors.New("invalid security action or availability"))
 	default:
 		return failure("signing_wrong_role", errors.New("unknown target role"))
+	}
+	return nil
+}
+
+type registryAttestationSubject struct {
+	Package    string       `json:"package"`
+	Owner      string       `json:"owner"`
+	Name       string       `json:"name"`
+	Version    string       `json:"version"`
+	Blob       AttestedBlob `json:"blob"`
+	Visibility string       `json:"visibility"`
+}
+
+type registryAttestationProjection struct {
+	Subject                 registryAttestationSubject `json:"subject"`
+	PublisherPrincipal      string                     `json:"publisher_principal"`
+	RegistryServiceIdentity string                     `json:"registry_service_identity"`
+	SourceRepository        AttestedRepository         `json:"source_repository"`
+	SourceCommit            AttestedCommit             `json:"source_commit"`
+	Review                  AttestedReview             `json:"review"`
+	ActivatedAt             string                     `json:"activated_at"`
+}
+
+func registryAttestationDigest(custom TargetCustom) (string, error) {
+	projection := registryAttestationProjection{
+		Subject: registryAttestationSubject{
+			Package: custom.Package, Owner: custom.Owner, Name: custom.Name,
+			Version: custom.Version, Blob: custom.Blob, Visibility: custom.Visibility,
+		},
+		PublisherPrincipal: custom.PublisherPrincipal, RegistryServiceIdentity: custom.RegistryServiceIdentity,
+		SourceRepository: custom.SourceRepository, SourceCommit: custom.SourceCommit,
+		Review: custom.Review, ActivatedAt: custom.ActivatedAt,
+	}
+	raw, err := json.Marshal(projection)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := CanonicalJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	return digest(canonical), nil
+}
+
+func (v *Verifier) validateRegistryAttestation(custom TargetCustom) error {
+	if !principalPattern.MatchString(custom.PublisherPrincipal) || !servicePattern.MatchString(custom.RegistryServiceIdentity) {
+		return failure("signing_target_attestation_invalid", errors.New("publisher or registry service identity is invalid"))
+	}
+	repository := custom.SourceRepository
+	if repository.Forge != "github" && repository.Forge != "gitlab" {
+		return failure("signing_target_attestation_invalid", errors.New("source forge is invalid"))
+	}
+	if !sourceIDPattern.MatchString(repository.RepositoryID) || validateSourceRepositoryURL(repository.CanonicalURL) != nil {
+		return failure("signing_target_attestation_invalid", errors.New("source repository identity is invalid"))
+	}
+	commitLength := 0
+	switch custom.SourceCommit.Algorithm {
+	case "sha1":
+		commitLength = 40
+	case "sha256":
+		commitLength = 64
+	default:
+		return failure("signing_target_attestation_invalid", errors.New("source commit algorithm is invalid"))
+	}
+	if len(custom.SourceCommit.Value) != commitLength || !commitPattern.MatchString(custom.SourceCommit.Value) {
+		return failure("signing_target_attestation_invalid", errors.New("source commit digest is invalid"))
+	}
+	review := custom.Review
+	if review.Result != "passed" || review.PolicyVersion == "" || len(review.PolicyVersion) > 128 ||
+		!proofIDPattern.MatchString(review.SourceProofID) || !validDigest(review.SourceProofSHA256) ||
+		!scanIDPattern.MatchString(review.ScanAttestationID) || !validDigest(review.ScanAttestationSHA256) ||
+		review.ScannerID == "" || len(review.ScannerID) > 128 || review.ScannerVersion == "" || len(review.ScannerVersion) > 128 ||
+		review.AttestationSequence < 1 {
+		return failure("signing_target_attestation_invalid", errors.New("review attestation is incomplete"))
+	}
+	if custom.SourceProofSHA256 != review.SourceProofSHA256 {
+		return failure("signing_target_attestation_invalid", errors.New("source proof digest does not match review"))
+	}
+	activated, err := time.Parse(time.RFC3339, custom.ActivatedAt)
+	if err != nil || !strings.HasSuffix(custom.ActivatedAt, "Z") || activated.After(v.config.Now().UTC().Add(5*time.Minute)) {
+		return failure("signing_target_attestation_invalid", errors.New("activation time is invalid"))
+	}
+	attestationDigest, err := registryAttestationDigest(custom)
+	if err != nil || !validDigest(custom.RegistryAttestationSHA256) ||
+		custom.RegistryAttestationSHA256 != attestationDigest || custom.ProvenanceSHA256 != attestationDigest {
+		return failure("signing_target_attestation_invalid", errors.New("registry attestation digest does not bind canonical provenance"))
+	}
+	return nil
+}
+
+func validateSourceRepositoryURL(value string) error {
+	if !sourceURLPattern.MatchString(value) {
+		return errors.New("canonical HTTPS source repository URL required")
+	}
+	u, err := url.Parse(value)
+	if err != nil || !u.IsAbs() || u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Port() != "" || u.Path == "" || u.Path == "/" {
+		return errors.New("canonical HTTPS source repository URL required")
+	}
+	if u.String() != value || strings.HasSuffix(value, "/") || u.Host != u.Hostname() {
+		return errors.New("source repository URL is not byte-canonical")
 	}
 	return nil
 }

--- a/tools/seen-pkg/internal/tuf/verify_test.go
+++ b/tools/seen-pkg/internal/tuf/verify_test.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	testEnvironment = "production"
-	testRepository  = "seen-prod-registry-v1"
-	testOrigin      = "https://seen.yousef.codes/packages"
-	testTargetPath  = "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz"
+	testEnvironment       = "production"
+	testRepository        = "seen-prod-registry-v1"
+	testOrigin            = "https://seen.yousef.codes/packages"
+	testTargetPath        = "packages/alice/mathx/1.2.3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/mathx-1.2.3.seenpkg.tgz"
+	fixtureActivationTime = "2026-07-16T11:59:00Z"
 )
 
 type signingKey struct {
@@ -37,6 +38,22 @@ type fixture struct {
 	targets   TargetsSigned
 	snapshot  SnapshotSigned
 	timestamp TimestampSigned
+}
+
+type clientConformanceContract struct {
+	Cases []clientConformanceCase `json:"client_conformance_cases"`
+}
+
+type clientConformanceCase struct {
+	Name         string                  `json:"name"`
+	InitialState string                  `json:"initial_state"`
+	Steps        []clientConformanceStep `json:"steps"`
+}
+
+type clientConformanceStep struct {
+	Action    string `json:"action"`
+	Expected  string `json:"expected"`
+	ErrorCode string `json:"error_code"`
 }
 
 func newSigningKey(t *testing.T) signingKey {
@@ -135,11 +152,29 @@ func newFixture(t *testing.T) fixture {
 
 	baseCustom := TargetCustom{
 		Environment: testEnvironment, RegistryOrigin: testOrigin, Package: "alice/mathx", Version: "1.2.3",
+		Owner: "alice", Name: "mathx",
 		ArchiveSHA256: strings.Repeat("a", 64), ArchiveFilename: "mathx-1.2.3.seenpkg.tgz",
+		Blob:               AttestedBlob{SHA256: strings.Repeat("a", 64), Length: 8192},
+		PublisherPrincipal: "publisher:alice", RegistryServiceIdentity: "release-promoter",
+		SourceRepository: AttestedRepository{Forge: "github", RepositoryID: "987654321", CanonicalURL: "https://github.com/alice/mathx"},
+		SourceCommit:     AttestedCommit{Algorithm: "sha1", Value: "0123456789abcdef0123456789abcdef01234567"},
+		Review: AttestedReview{
+			Result: "passed", PolicyVersion: "package-scan-v1.0.0",
+			SourceProofID: "prf_01JZX8K9F7Q2W4N6M8R0", SourceProofSHA256: strings.Repeat("b", 64),
+			ScanAttestationID: "scn_01JZX9M1N2P3Q4R5S6T7", ScanAttestationSHA256: strings.Repeat("d", 64),
+			ScannerID: "seen-package-scanner", ScannerVersion: "1.0.0", AttestationSequence: 4,
+		},
 		Visibility: "public", Lifecycle: "active", Retention: "retained", Availability: "available",
-		SourceProofSHA256: strings.Repeat("b", 64), ProvenanceSHA256: strings.Repeat("c", 64),
-		Dependencies: []TargetDependency{}, Capabilities: []string{"file"},
+		ActivatedAt:       fixtureActivationTime,
+		SourceProofSHA256: strings.Repeat("b", 64),
+		Dependencies:      []TargetDependency{}, Capabilities: []string{"file"},
 	}
+	attestationSHA256, err := registryAttestationDigest(baseCustom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseCustom.RegistryAttestationSHA256 = attestationSHA256
+	baseCustom.ProvenanceSHA256 = attestationSHA256
 	baseTarget := TargetMeta{Length: 8192, Hashes: map[string]string{"sha256": strings.Repeat("a", 64)}, Custom: baseCustom}
 	releases := TargetsSigned{Common: common("targets", 42, now.Add(4*24*time.Hour)), Targets: map[string]TargetMeta{testTargetPath: baseTarget}}
 	securityTarget := baseTarget
@@ -194,6 +229,225 @@ func tufCode(t *testing.T, err error) string {
 		t.Fatalf("expected TUF Error, got %T: %v", err, err)
 	}
 	return verification.Code
+}
+
+func loadClientConformanceCases(t *testing.T) map[string]clientConformanceCase {
+	t.Helper()
+	fixturePath := filepath.Join("..", "..", "..", "..", "contracts", "package-registry", "v1", "fixtures", "tuf-metadata-examples.json")
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var contract clientConformanceContract
+	if err := json.Unmarshal(raw, &contract); err != nil {
+		t.Fatal(err)
+	}
+	cases := make(map[string]clientConformanceCase, len(contract.Cases))
+	for _, item := range contract.Cases {
+		if item.Name == "" || len(item.Steps) == 0 {
+			t.Fatalf("invalid client conformance case: %+v", item)
+		}
+		if _, duplicate := cases[item.Name]; duplicate {
+			t.Fatalf("duplicate client conformance case %q", item.Name)
+		}
+		cases[item.Name] = item
+	}
+	return cases
+}
+
+func requireConformanceSteps(t *testing.T, item clientConformanceCase, initialState string, actions ...string) {
+	t.Helper()
+	if item.InitialState != initialState {
+		t.Fatalf("%s initial state = %q, want %q", item.Name, item.InitialState, initialState)
+	}
+	if len(item.Steps) != len(actions) {
+		t.Fatalf("%s steps = %d, want %d", item.Name, len(item.Steps), len(actions))
+	}
+	for index, action := range actions {
+		if item.Steps[index].Action != action {
+			t.Fatalf("%s step %d action = %q, want %q", item.Name, index, item.Steps[index].Action, action)
+		}
+	}
+}
+
+func assertConformanceResult(t *testing.T, step clientConformanceStep, err error) {
+	t.Helper()
+	switch step.Expected {
+	case "accept":
+		if step.ErrorCode != "" {
+			t.Fatalf("accepted conformance step declares error code %q", step.ErrorCode)
+		}
+		if err != nil {
+			t.Fatalf("conformance step rejected: %v", err)
+		}
+	case "reject":
+		if err == nil {
+			t.Fatal("conformance step unexpectedly accepted")
+		}
+		if got := tufCode(t, err); got != step.ErrorCode {
+			t.Fatalf("conformance error = %q, want %q: %v", got, step.ErrorCode, err)
+		}
+	default:
+		t.Fatalf("unknown conformance expectation %q", step.Expected)
+	}
+}
+
+func bootstrapAndRefreshFixture(t *testing.T, fixture fixture) *Verifier {
+	t.Helper()
+	verifier := verifierFor(t, fixture, &MemoryStore{})
+	if err := verifier.BootstrapRoot(fixture.root, digest(fixture.root)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.Refresh(fixture.metadata); err != nil {
+		t.Fatal(err)
+	}
+	return verifier
+}
+
+func advanceReleaseTransaction(t *testing.T, fixture *fixture, signer signingKey) {
+	t.Helper()
+	fixture.releases.Version++
+	fixture.snapshot.Version++
+	fixture.timestamp.Version++
+	fixture.rebuildWithDelegatedSigners(t, signer, fixture.keys["security-a"])
+}
+
+func replaceReleaseDelegation(t *testing.T, fixture *fixture, replacement signingKey) {
+	t.Helper()
+	if fixture.targets.Delegations == nil {
+		t.Fatal("fixture has no delegated targets policy")
+	}
+	roles := append([]DelegatedRole(nil), fixture.targets.Delegations.Roles...)
+	found := false
+	for index := range roles {
+		if roles[index].Name == "releases" {
+			roles[index].KeyIDs = []string{replacement.id}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("fixture has no releases delegation")
+	}
+	fixture.targets.Delegations = &Delegations{
+		Keys: map[string]Key{
+			replacement.id:                tufKey(replacement),
+			fixture.keys["security-a"].id: tufKey(fixture.keys["security-a"]),
+		},
+		Roles: roles,
+	}
+	fixture.targets.Version++
+	fixture.releases.Version++
+	fixture.snapshot.Version++
+	fixture.timestamp.Version++
+}
+
+func runWrongEnvironmentConformance(t *testing.T, item clientConformanceCase) {
+	requireConformanceSteps(t, item, "trusted-root-only", "refresh-complete-chain-resigned-with-release-environment-changed")
+	fixture := newFixture(t)
+	fixture.releases.Environment = "development"
+	fixture.rebuild(t)
+	verifier := verifierFor(t, fixture, &MemoryStore{})
+	if err := verifier.BootstrapRoot(fixture.root, digest(fixture.root)); err != nil {
+		t.Fatal(err)
+	}
+	_, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[0], err)
+}
+
+func runMissingMetadataConformance(t *testing.T, item clientConformanceCase) {
+	requireConformanceSteps(t, item, "trusted-root-only", "refresh-complete-chain-with-security-metadata-absent")
+	fixture := newFixture(t)
+	store := &MemoryStore{}
+	verifier := verifierFor(t, fixture, store)
+	if err := verifier.BootstrapRoot(fixture.root, digest(fixture.root)); err != nil {
+		t.Fatal(err)
+	}
+	fixture.metadata.Security = nil
+	_, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[0], err)
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Versions["timestamp"] != 0 || state.Versions["snapshot"] != 0 || state.Versions["security"] != 0 {
+		t.Fatalf("missing metadata advanced trusted state: %+v", state.Versions)
+	}
+}
+
+func runCompromisedCurrentKeyConformance(t *testing.T, item clientConformanceCase) {
+	requireConformanceSteps(t, item, "base-metadata-refreshed", "refresh-next-release-version-signed-by-current-delegated-key")
+	fixture := newFixture(t)
+	verifier := bootstrapAndRefreshFixture(t, fixture)
+	target := fixture.releases.Targets[testTargetPath]
+	target.Custom.Availability = "yanked"
+	target.Custom.YankReason = "compromised delegated key changed availability"
+	fixture.releases.Targets[testTargetPath] = target
+	advanceReleaseTransaction(t, &fixture, fixture.keys["releases-a"])
+	_, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[0], err)
+}
+
+func runRevokedDelegationConformance(t *testing.T, item clientConformanceCase) {
+	requireConformanceSteps(t, item, "base-metadata-refreshed", "refresh-resigned-chain-after-offline-targets-replaces-release-key-but-release-uses-former-key")
+	fixture := newFixture(t)
+	verifier := bootstrapAndRefreshFixture(t, fixture)
+	former := fixture.keys["releases-a"]
+	replacement := newSigningKey(t)
+	replaceReleaseDelegation(t, &fixture, replacement)
+	fixture.rebuildWithDelegatedSigners(t, former, fixture.keys["security-a"])
+	_, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[0], err)
+}
+
+func runRecoveryConformance(t *testing.T, item clientConformanceCase) {
+	requireConformanceSteps(
+		t,
+		item,
+		"base-metadata-refreshed",
+		"reject-resigned-chain-after-offline-targets-replaces-release-key-but-release-uses-former-key",
+		"refresh-same-next-versions-resigned-by-replacement-release-key",
+	)
+	fixture := newFixture(t)
+	verifier := bootstrapAndRefreshFixture(t, fixture)
+	former := fixture.keys["releases-a"]
+	replacement := newSigningKey(t)
+	replaceReleaseDelegation(t, &fixture, replacement)
+	fixture.rebuildWithDelegatedSigners(t, former, fixture.keys["security-a"])
+	_, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[0], err)
+
+	// The failed transaction did not advance trust. Re-signing the same next
+	// signed versions with the newly delegated key must therefore recover.
+	fixture.rebuildWithDelegatedSigners(t, replacement, fixture.keys["security-a"])
+	repository, err := verifier.Refresh(fixture.metadata)
+	assertConformanceResult(t, item.Steps[1], err)
+	if repository == nil || repository.Releases.Version != fixture.releases.Version {
+		t.Fatalf("recovery did not install replacement metadata: %+v", repository)
+	}
+}
+
+func TestFrozenClientConformanceCases(t *testing.T) {
+	cases := loadClientConformanceCases(t)
+	runners := []struct {
+		name string
+		run  func(*testing.T, clientConformanceCase)
+	}{
+		{"wrong-environment-signed-chain", runWrongEnvironmentConformance},
+		{"missing-delegated-metadata", runMissingMetadataConformance},
+		{"compromised-online-key-remains-authorized-before-revocation", runCompromisedCurrentKeyConformance},
+		{"revoked-delegation-rejects-former-online-key", runRevokedDelegationConformance},
+		{"replacement-delegation-recovers-after-compromise", runRecoveryConformance},
+	}
+	if len(cases) != len(runners) {
+		t.Fatalf("client conformance cases = %d, want %d", len(cases), len(runners))
+	}
+	for _, runner := range runners {
+		item, ok := cases[runner.name]
+		if !ok {
+			t.Fatalf("missing client conformance case %q", runner.name)
+		}
+		t.Run(runner.name, func(t *testing.T) { runner.run(t, item) })
+	}
 }
 
 func TestRefreshVerifiesChainAndSecurityOverlay(t *testing.T) {
@@ -281,6 +535,13 @@ func TestMetadataHashLengthAndOriginFailClosed(t *testing.T) {
 			mutate: func(f *fixture) {
 				target := f.security.Targets[testTargetPath]
 				target.Length++
+				target.Custom.Blob.Length = target.Length
+				attestationSHA256, err := registryAttestationDigest(target.Custom)
+				if err != nil {
+					t.Fatal(err)
+				}
+				target.Custom.RegistryAttestationSHA256 = attestationSHA256
+				target.Custom.ProvenanceSHA256 = attestationSHA256
 				f.security.Targets[testTargetPath] = target
 				f.rebuild(t)
 			},
@@ -305,10 +566,111 @@ func TestMetadataHashLengthAndOriginFailClosed(t *testing.T) {
 	}
 }
 
+func TestRegistryAttestationFailsClosed(t *testing.T) {
+	baseFixture := newFixture(t)
+	tests := []struct {
+		name   string
+		mutate func(*TargetCustom)
+	}{
+		{
+			name: "publisher principal missing",
+			mutate: func(custom *TargetCustom) {
+				custom.PublisherPrincipal = ""
+			},
+		},
+		{
+			name: "source commit invalid",
+			mutate: func(custom *TargetCustom) {
+				custom.SourceCommit.Value = "not-a-commit"
+			},
+		},
+		{
+			name: "source repository identifier invalid",
+			mutate: func(custom *TargetCustom) {
+				custom.SourceRepository.RepositoryID = "repository id with spaces"
+			},
+		},
+		{
+			name: "source repository host is not canonical lowercase",
+			mutate: func(custom *TargetCustom) {
+				custom.SourceRepository.CanonicalURL = "https://GitHub.com/alice/mathx"
+			},
+		},
+		{
+			name: "source repository path is percent encoded",
+			mutate: func(custom *TargetCustom) {
+				custom.SourceRepository.CanonicalURL = "https://github.com/alice/math%78"
+			},
+		},
+		{
+			name: "source proof differs from review",
+			mutate: func(custom *TargetCustom) {
+				custom.SourceProofSHA256 = strings.Repeat("c", 64)
+			},
+		},
+		{
+			name: "activation is in the future",
+			mutate: func(custom *TargetCustom) {
+				custom.ActivatedAt = baseFixture.now.Add(10 * time.Minute).Format(time.RFC3339)
+			},
+		},
+		{
+			name: "canonical digest is stale",
+			mutate: func(custom *TargetCustom) {
+				custom.PublisherPrincipal = "publisher:bob"
+			},
+		},
+		{
+			name: "legacy provenance digest differs",
+			mutate: func(custom *TargetCustom) {
+				custom.ProvenanceSHA256 = strings.Repeat("c", 64)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newFixture(t)
+			target := fixture.releases.Targets[testTargetPath]
+			tc.mutate(&target.Custom)
+			fixture.releases.Targets[testTargetPath] = target
+			fixture.rebuild(t)
+
+			verifier := verifierFor(t, fixture, &MemoryStore{})
+			if err := verifier.BootstrapRoot(fixture.root, digest(fixture.root)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := verifier.Refresh(fixture.metadata); tufCode(t, err) != "signing_target_attestation_invalid" {
+				t.Fatalf("attestation mutation = %v", err)
+			}
+		})
+	}
+}
+
+func TestSecurityTargetRejectsYankReason(t *testing.T) {
+	fixture := newFixture(t)
+	target := fixture.security.Targets[testTargetPath]
+	target.Custom.YankReason = "release-role field must not cross the security boundary"
+	fixture.security.Targets[testTargetPath] = target
+	fixture.rebuild(t)
+
+	verifier := verifierFor(t, fixture, &MemoryStore{})
+	if err := verifier.BootstrapRoot(fixture.root, digest(fixture.root)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.Refresh(fixture.metadata); tufCode(t, err) != "signing_metadata_invalid" {
+		t.Fatalf("security target with yank reason = %v", err)
+	}
+}
+
 func (f *fixture) rebuild(t *testing.T) {
+	f.rebuildWithDelegatedSigners(t, f.keys["releases-a"], f.keys["security-a"])
+}
+
+func (f *fixture) rebuildWithDelegatedSigners(t *testing.T, releasesSigner, securitySigner signingKey) {
 	t.Helper()
-	f.metadata.Releases = envelopeFor(t, f.releases, map[string]signingKey{"releases-a": f.keys["releases-a"]})
-	f.metadata.Security = envelopeFor(t, f.security, map[string]signingKey{"security-a": f.keys["security-a"]})
+	f.metadata.Releases = envelopeFor(t, f.releases, map[string]signingKey{"releases-a": releasesSigner})
+	f.metadata.Security = envelopeFor(t, f.security, map[string]signingKey{"security-a": securitySigner})
 	f.metadata.Targets = envelopeFor(t, f.targets, map[string]signingKey{"targets-a": f.keys["targets-a"]})
 	f.snapshot.Meta = map[string]FileMeta{
 		"targets.json":  fileMeta(t, f.targets.Version, f.metadata.Targets),


### PR DESCRIPTION
Implements the client and shared-contract side of FEL-633.

- binds signed targets to package identity, blob, publisher/service, source, review, visibility, and activation evidence
- verifies canonical registry attestations and rejects malformed or mixed metadata
- adds frozen compromise, revocation, recovery, and target-binding conformance cases
- keeps fixture-clock verification deterministic

Verification:
- `python3 tests/package_registry_contracts.py`
- `go test ./...` in `tools/seen-pkg` with bounded memory

This is stacked on the FEL-632 contract branch.