### PR TITLE
FEL-642: ignore local repository state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ installer/windows/output/
 installer/macos/*.pkg
 installer/macos/*.pkg.sha256
 .leann/
+/.gradle/
 
 # IDE specific files
 .idea/
@@ -196,6 +197,7 @@ README_VERIFICATION.md
 /docs/private/
 
 # Internal tooling
+/.agents/
 /.claude/
 CLAUDE.md
 llms.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@
 
 - Do not run project builds or rebuild scripts without an explicit memory limit derived from current system memory.
 - Prefer capped serial or low-memory rebuild paths when available.
+
+## Repository hygiene
+
+- Keep generated build/test output and agent-local state in ignored paths; do not stage it.


### PR DESCRIPTION
## Summary

- ignore the repository-local Gradle output currently produced by portfolio integration checks
- ignore agent-local state
- add a durable instruction preventing generated build/test output and agent-local state from being staged

## Validation

- branch is based directly on current `origin/main` and contains no FEL-633 commits
- `git diff --check`
- `git check-ignore -v --no-index .gradle/sentinel .agents/sentinel`

No compiler or runtime source changed, so no project build is required.
